### PR TITLE
docs(core): fix typo in comparison page

### DIFF
--- a/apps/docs/content/docs/core/comparison.mdx
+++ b/apps/docs/content/docs/core/comparison.mdx
@@ -26,6 +26,6 @@ Comparison of the following deployment tools:
 | **Open Source Templates**               | ✅      | ✅                    | ❌                    | ✅      | 
 | **Schedules Jobs**                      | ❌      | ❌                    | ❌                    | ✅      | 
 | **Cloudflare Tunnels**                  | ❌      | ❌                    | ❌                    | ✅      | 
-| **Previes Deployments**                 | ❌      | ❌                    | ❌                    | ✅      | 
+| **Preview Deployments**                 | ❌      | ❌                    | ❌                    | ✅      | 
 | **Teams**                               | ❌      | ❌                    | ❌                    | ✅      |
 | **Cloud/Paid Version**                  | ✅      | ✅                    | ✅                    | ✅      |


### PR DESCRIPTION
I changed from `Previes Deployments` to `Preview Deployments`.