### PR TITLE
docs: fix typo on the goodies page

### DIFF
--- a/apps/docs/content/docs/core/goodies.mdx
+++ b/apps/docs/content/docs/core/goodies.mdx
@@ -5,7 +5,7 @@ description: "Dokploy has certain goodies that are external that can be used wit
 
 
 1. **Ansible Dokploy**: Ansible role to deploy Dokploy [Ansible Role](https://github.com/jacobtipp/ansible-dokploy)
-2. **Dokplo Oracle infrastructure**: Deploy Dokploy on Oracle infrastructure [Github](https://github.com/statickidz/dokploy-oci-free)
+2. **Dokploy Oracle infrastructure**: Deploy Dokploy on Oracle infrastructure [Github](https://github.com/statickidz/dokploy-oci-free)
 3. **Dokploy Deploy Action 1**: Automatic Dokploy deploments on Github [Github](https://github.com/benbristow/dokploy-deploy-action)
 4. **Dokploy Deploy Action 2**: Automatic Dokploy deploments on Github [Github](https://github.com/jmischler72/dokploy-deploy-action)
 5. **Dokploy JS Sdk**: Dokploy JS SDK [Github](https://github.com/quiint/dokploy.js)


### PR DESCRIPTION
"Dokplo" - The missing letter **y** has been added