### PR TITLE
fix(docs/email): SMPT -> SMTP

### DIFF
--- a/apps/docs/content/docs/core/(Notifications)/email.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/email.mdx
@@ -12,7 +12,7 @@ For start receiving email notifications, you need to fill the form with the foll
 
 
 1. **Name**: Enter any name you want.
-2. **SMPT Server**: Enter the SMTP server address. eg. `smtp.gmail.com`
+2. **SMTP Server**: Enter the SMTP server address. eg. `smtp.gmail.com`
 3. **SMTP Port**: Enter the SMTP server port. eg. `587`
 4. **SMTP Username**: Enter the SMTP server username. eg. `your-email@gmail.com`
 5. **SMTP Password**: Enter the SMTP server password.


### PR DESCRIPTION
@Siumauricio Fixes typo [here](https://docs.dokploy.com/docs/core/email).

SMPT -> SMTP