### PR TITLE
fix: correct spelling of "deployments" in documentation

### DIFF
--- a/apps/docs/content/docs/core/goodies.mdx
+++ b/apps/docs/content/docs/core/goodies.mdx
@@ -3,11 +3,10 @@ title: Goodies
 description: "Dokploy has certain goodies that are external that can be used with Dokploy."
 ---
 
-
 1. **Ansible Dokploy**: Ansible role to deploy Dokploy [Ansible Role](https://github.com/jacobtipp/ansible-dokploy)
 2. **Dokploy Oracle infrastructure**: Deploy Dokploy on Oracle infrastructure [Github](https://github.com/statickidz/dokploy-oci-free)
-3. **Dokploy Deploy Action 1**: Automatic Dokploy deploments on Github [Github](https://github.com/benbristow/dokploy-deploy-action)
-4. **Dokploy Deploy Action 2**: Automatic Dokploy deploments on Github [Github](https://github.com/jmischler72/dokploy-deploy-action)
+3. **Dokploy Deploy Action 1**: Automatic Dokploy deployments on Github [Github](https://github.com/benbristow/dokploy-deploy-action)
+4. **Dokploy Deploy Action 2**: Automatic Dokploy deployments on Github [Github](https://github.com/jmischler72/dokploy-deploy-action)
 5. **Dokploy JS Sdk**: Dokploy JS SDK [Github](https://github.com/quiint/dokploy.js)
 6. **Templates Collection** : Docker compose collection for Dokploy [Github](https://github.com/benbristow/dokploy-compose-templates)
 7. **Dokploy Port Updater**: Dokploy Port Updater [Github](https://github.com/clockradios/dokploy-port-updater)


### PR DESCRIPTION
This pull request includes a small but important change to the `apps/docs/content/docs/core/goodies.mdx` file. The change corrects a typographical error in the description of two Dokploy deployment actions.

Typographical corrections:

* [`apps/docs/content/docs/core/goodies.mdx`](diffhunk://#diff-964c4df3c06029c30b0e87e6e724742d0234cee986c9020746ff3a73c038aebdL6-R9): Corrected the word "deploments" to "deployments" in the descriptions for "Dokploy Deploy Action 1" and "Dokploy Deploy Action 2".