### PR TITLE
docs: use correct header name

### DIFF
--- a/apps/docs/content/docs/core/auto-deploy.mdx
+++ b/apps/docs/content/docs/core/auto-deploy.mdx
@@ -89,7 +89,7 @@ Steps:
 curl -X 'GET' \
   'https://your-domain/api/project.all' \
   -H 'accept: application/json'
-  -H 'x-api-token: <token>'
+  -H 'x-api-key: <token>'
 ```
 
 This command lists all projects and services. Identify the applicationId for the application you wish to deploy.
@@ -101,7 +101,7 @@ curl -X 'POST' \
   'https://your-domain/api/application.deploy' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  -H 'x-api-token: <token>' \
+  -H 'x-api-key: <token>' \
   -d '{
   "applicationId": "string"
 }'

--- a/apps/docs/content/docs/core/auto-deploy.mdx
+++ b/apps/docs/content/docs/core/auto-deploy.mdx
@@ -89,7 +89,7 @@ Steps:
 curl -X 'GET' \
   'https://your-domain/api/project.all' \
   -H 'accept: application/json'
-  -H 'Authorization: Bearer <token>'
+  -H 'x-api-token: <token>'
 ```
 
 This command lists all projects and services. Identify the applicationId for the application you wish to deploy.
@@ -101,7 +101,7 @@ curl -X 'POST' \
   'https://your-domain/api/application.deploy' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <token>' \
+  -H 'x-api-token: <token>' \
   -d '{
   "applicationId": "string"
 }'


### PR DESCRIPTION
In the docs, it's mentioned to use `Authorization: Bearer <token>` for making curl requests, but that doesn't work, instead using `x-api-token` header works.  [Reference](https://github.com/Dokploy/website/issues/28)