### PR TITLE
docs(core): add curl to requirements for rollbacks

### DIFF
--- a/apps/docs/content/docs/core/applications/rollbacks.mdx
+++ b/apps/docs/content/docs/core/applications/rollbacks.mdx
@@ -9,6 +9,7 @@ Rollbacks are a powerful feature that allows you to easily revert changes to you
 ## Requirements
 
 1. Have a `/health` endpoint in your application.
+2. Have `curl` available in your container (if you use alpine for example, it won't be installed by default).
 
 ## Steps to Rollback
 


### PR DESCRIPTION
The health check fails silently if `curl` isn't available.
