### PR TITLE
fix(website): duplicate key for children in `stats.tsx`

### DIFF
--- a/apps/website/components/stats.tsx
+++ b/apps/website/components/stats.tsx
@@ -158,10 +158,10 @@ export function GridPattern({ width, height, x, y, squares, ...props }: any) {
 			/>
 			{squares && (
 				<svg x={x} y={y} className="overflow-visible">
-					{squares.map(([x, y]: any) => (
+					{squares.map(([x, y]: any, i: number) => (
 						<rect
 							strokeWidth="0"
-							key={`${x}-${y}`}
+							key={`${x}-${y}-${i}`}
 							width={width + 1}
 							height={height + 1}
 							x={x * width}


### PR DESCRIPTION
This PR fixes this error when running the website locally:

<img width="969" alt="image" src="https://github.com/user-attachments/assets/ab97a6e2-3840-4f2f-b126-a54f1fe881bc" />
