### PR TITLE
docs: remove outdated toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ Before you start, please first discuss the feature/bug you want to add with the 
 
 We have a few guidelines to follow when contributing to this project:
 
-- [Commit Convention](#commit-convention)
-- [Setup](#setup)
-- [Development](#development)
-- [Build](#build)
-- [Pull Request](#pull-request)
-
 ## Commit Convention
 
 Before you create a Pull Request, please make sure your commit message follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.


### PR DESCRIPTION
The table of contents in `README.md` went out of sync with the actual content 8 months ago with dc351dc202cfda492dbb61c79a08922efa8d290e causing some links to be broken. Since the document isn't that long anywy I figured it'd be better if there's no toc to maintain in the first place.