### PR TITLE
Improve/fix the 2FA documentation

### DIFF
--- a/apps/docs/content/docs/core/reset-password.mdx
+++ b/apps/docs/content/docs/core/reset-password.mdx
@@ -46,7 +46,7 @@ It will display a random password. Copy it and use it to access again to the das
 
 To disable 2FA, follow these steps:
 
-To reset your password, follow these steps:
+To reset your 2FA, follow these steps:
 
 <Steps>
 <Step>
@@ -75,7 +75,7 @@ Run command below to open a shell in the dokploy container.
 </Step>
 <Step>
 
-It will display a random password. Copy it and use it to access again to the dashboard.
+You can now logic again without having to supply a 2FA code.
 
 </Step>
 </Steps>


### PR DESCRIPTION
Just a few simple wording fixes and tweaks for the 2FA documentation.
Mainly a removal of the wording of `password`, and improving the last `Step` of the docs.