### PR TITLE
docs: Update comparison.mdx - fix Caprover features

### DIFF
--- a/apps/docs/content/docs/core/comparison.mdx
+++ b/apps/docs/content/docs/core/comparison.mdx
@@ -6,7 +6,7 @@ description: "A comparison of Dokploy, CapRover, Dokku, and Coolify"
 Comparison of the following deployment tools:
 
 | Feature                                 | Dokploy | CapRover              | Dokku                 | Coolify |
-| ----------------------------------------| ------- | --------------------- | --------------------- | ------- |
+| --------------------------------------- | ------- | --------------------- | --------------------- | ------- |
 | **User Interface**                      | ✅      | ✅                    | ❌                    | ✅      |
 | **Docker compose support**              | ✅      | ❌                    | ❌                    | ✅      |
 | **API/CLI**                             | ✅      | ✅                    | ✅                    | ✅      |

--- a/apps/docs/content/docs/core/comparison.mdx
+++ b/apps/docs/content/docs/core/comparison.mdx
@@ -13,14 +13,14 @@ Comparison of the following deployment tools:
 | **Multi node support**                  | ✅      | ✅                    | ❌                    | ✅      |
 | **Traefik Integration**                 | ✅      | ✅                    | Available via Plugins | ✅      |
 | **User Permission Management**          | ✅      | ❌                    | ❌                    | ✅      |
-| **Bitbucket Integration**               | ✅      | ❌                    | ❌                    | ❌      |
-| **Gitlab Integration**                  | ✅      | ❌                    | ❌                    | ❌      |
+| **Bitbucket Integration**               | ✅      | ✅                    | ❌                    | ❌      |
+| **Gitlab Integration**                  | ✅      | ✅                    | ❌                    | ❌      |
 | **Gitea Integration**                   | ✅      | ❌                    | ✅                    | ❌      |
 | **Advanced User Permission Management** | ✅      | ❌                    | ❌                    | ❌      |
 | **Terminal Access Built In**            | ✅      | ❌                    | ❌                    | ✅      |
 | **Database Support**                    | ✅      | ✅                    | ❌                    | ✅      |
 | **Monitoring**                          | ✅      | ✅                    | ❌                    | ❌      |
-| **Backups**                             | ✅      | Available via Plugins | Available via Plugins | ✅      |
+| **Backups**                             | ✅      | ✅                    | Available via Plugins | ✅      |
 | **Open Source**                         | ✅      | ✅                    | ✅                    | ✅      |
 | **Notifications**                       | ✅      | ❌                    | ❌                    | ✅      |
 | **Multi Server Support**                | ✅      | ❌                    | ❌                    | ✅      |
@@ -29,7 +29,7 @@ Comparison of the following deployment tools:
 | **Shared Enviroment Variables**         | ✅      | ❌                    | ❌                    | ✅      | 
 | **Schedules Jobs**                      | ✅      | ❌                    | ❌                    | ✅      | 
 | **Cloudflare Tunnels**                  | ❌      | ❌                    | ❌                    | ✅      |
-| **Volume Backups**                      | ✅      | ❌                    | ❌                    | ❌      |
+| **Volume Backups**                      | ✅      | Available via Plugins | ❌                    | ❌      |
 | **Preview Deployments**                 | ✅      | ❌                    | ❌                    | ✅      | 
 | **Teams**                               | ✅      | ❌                    | ❌                    | ✅      |
 | **Cloud/Paid Version**                  | ✅      | ✅                    | ✅                    | ✅      |

--- a/apps/docs/content/docs/core/comparison.mdx
+++ b/apps/docs/content/docs/core/comparison.mdx
@@ -6,16 +6,16 @@ description: "A comparison of Dokploy, CapRover, Dokku, and Coolify"
 Comparison of the following deployment tools:
 
 | Feature                                 | Dokploy | CapRover              | Dokku                 | Coolify |
-| --------------------------------------- | ------- | --------------------- | --------------------- | ------- |
+| ----------------------------------------| ------- | --------------------- | --------------------- | ------- |
 | **User Interface**                      | ✅      | ✅                    | ❌                    | ✅      |
 | **Docker compose support**              | ✅      | ❌                    | ❌                    | ✅      |
 | **API/CLI**                             | ✅      | ✅                    | ✅                    | ✅      |
 | **Multi node support**                  | ✅      | ✅                    | ❌                    | ✅      |
 | **Traefik Integration**                 | ✅      | ✅                    | Available via Plugins | ✅      |
 | **User Permission Management**          | ✅      | ❌                    | ❌                    | ✅      |
-| **Bitbucket Integration**               | ✅      | ✅                    | ❌                    | ❌      |
-| **Gitlab Integration**                  | ✅      | ✅                    | ❌                    | ❌      |
-| **Gitea Integration**                   | ✅      | ❌                    | ✅                    | ❌      |
+| **Bitbucket Integration** [^*]          | ✅      | ❌                    | ❌                    | ❌      |
+| **Gitlab Integration** [^*]             | ✅      | ❌                    | ❌                    | ❌      |
+| **Gitea Integration** [^*]              | ✅      | ❌                    | ✅                    | ❌      |
 | **Advanced User Permission Management** | ✅      | ❌                    | ❌                    | ❌      |
 | **Terminal Access Built In**            | ✅      | ❌                    | ❌                    | ✅      |
 | **Database Support**                    | ✅      | ✅                    | ❌                    | ✅      |
@@ -33,3 +33,6 @@ Comparison of the following deployment tools:
 | **Preview Deployments**                 | ✅      | ❌                    | ❌                    | ✅      | 
 | **Teams**                               | ✅      | ❌                    | ❌                    | ✅      |
 | **Cloud/Paid Version**                  | ✅      | ✅                    | ✅                    | ✅      |
+
+
+[^*]: Dokploy offers dedicated integration with autocompletion of repository and branch names using oauth apps.


### PR DESCRIPTION
This PR should improve comparison of Dokploy with Caprover:
+ Gitlab/Bitbucket integration [source](https://caprover.com/docs/deployment-methods.html#automatic-deploy-using-github-bitbucket-and-etc)
+ Backup [source](https://caprover.com/docs/backup-and-restore.html)
+ Volume Backups [via Offen one-click app](https://github.com/caprover/one-click-apps/blob/master/public/v4/apps/offen-docker-backup.yml)