### PR TITLE
docs: fix typo

### DIFF
--- a/apps/docs/content/docs/core/reset-password.mdx
+++ b/apps/docs/content/docs/core/reset-password.mdx
@@ -75,7 +75,7 @@ Run command below to open a shell in the dokploy container.
 </Step>
 <Step>
 
-You can now logic again without having to supply a 2FA code.
+You can now login again without having to supply a 2FA code.
 
 </Step>
 </Steps>


### PR DESCRIPTION
Spotted a small typo in the docs on the **Reset Password & 2FA** page.