### PR TITLE
docs: add instructions on how to use cloudflare origin certificates

### DIFF
--- a/apps/docs/content/docs/core/domains/cloudflare.mdx
+++ b/apps/docs/content/docs/core/domains/cloudflare.mdx
@@ -40,10 +40,33 @@ Follow the steps in the same order to prevent any issues.
 </Callout>
 
 You can create a certificate for your origin server using two methods:
-- Using Cloudflare's Origin CA to generate a certificate for your origin server.
 - Using Let's Encrypt to generate a certificate for your origin server.
+- Using Cloudflare's Origin CA to generate a certificate for your origin server.
 
 We assume that you have enabled the `Full (Strict)` mode in the previous step, is super important to follow the steps in the same order to prevent any issues.
+
+### Using Let's Encrypt
+1. Go to cloudflare dashboard and then click on `Account Home` -> Select the Domain.
+2. On the left side, click `DNS`.
+3. Click on `Records`.
+4. Click on `Add Record`.
+5. Select `A` record type.
+6. Enter the `Host` name, eg. `api` so it will be `api.dokploy.com`.
+7. Enter the `IPv4 Address` from your server where the application is hosted eg. `1.2.3.4`.
+8. Click `Save`.
+9. Go to dokploy panel and now you can assign either for `Applications` or `Docker Compose`.
+10. Go to `Domains` section.
+11. Click `Create Domain`.
+12. In the `Host` field, enter the domain name eg. `api.dokploy.com`.
+13. In the `Path` field, enter the path eg. `/`.
+14. In the `Container Port` field, enter the port where your application is running eg. `3000`.
+15. In the `HTTPS` field enable `ON`.
+16. In the `Certificate` field select `Let's Encrypt`.
+17. Click `Create`.
+18. A domain will be automatically assigned to your application.
+19. Wait a few seconds and refresh the application.
+20. You should see the application running on the domain you just created.
+
 ### Using Cloudflare's Origin CA
 1. Go to cloudflare dashboard and then click on `Account Home` -> Select the Domain.
 2. On the left side, click `SSL/TLS`.
@@ -72,28 +95,6 @@ You can also create a certificate for wildcards domains eg. `*.dokploy.com` and 
 <Callout type="warn">
 **Important**: With a free Cloudflare account, this methods work only for the main domain and subdomains, not for sub-subdomains. Eg. `api.dokploy.com` works but `staging.api.dokploy.com` does not work.
 </Callout>
-
-### Using Let's Encrypt
-1. Go to cloudflare dashboard and then click on `Account Home` -> Select the Domain.
-2. On the left side, click `DNS`.
-3. Click on `Records`.
-4. Click on `Add Record`.
-5. Select `A` record type.
-6. Enter the `Host` name, eg. `api` so it will be `api.dokploy.com`.
-7. Enter the `IPv4 Address` from your server where the application is hosted eg. `1.2.3.4`.
-8. Click `Save`.
-9. Go to dokploy panel and now you can assign either for `Applications` or `Docker Compose`.
-10. Go to `Domains` section.
-11. Click `Create Domain`.
-12. In the `Host` field, enter the domain name eg. `api.dokploy.com`.
-13. In the `Path` field, enter the path eg. `/`.
-14. In the `Container Port` field, enter the port where your application is running eg. `3000`.
-15. In the `HTTPS` field enable `ON`.
-16. In the `Certificate` field select `Let's Encrypt`.
-17. Click `Create`.
-18. A domain will be automatically assigned to your application.
-19. Wait a few seconds and refresh the application.
-20. You should see the application running on the domain you just created.
 
 
 


### PR DESCRIPTION
This pull request adds detailed documentation on how to create an origin certificate for your server using Cloudflare's Origin CA. The new instructions clarify the process and requirements for each method, including step-by-step guidance and important caveats.
* Added a new section describing two methods for generating an origin certificate: using Cloudflare's Origin CA and using Let's Encrypt.
* Provided a step-by-step guide for generating and installing a certificate with Cloudflare's Origin CA, including instructions for handling hostnames, validity periods, and certificate installation in the Dokploy panel.
