### PR TITLE
docs: Remove self-hosted registry references and recommend external registries-#2575

### DIFF
--- a/apps/docs/content/docs/core/cluster.mdx
+++ b/apps/docs/content/docs/core/cluster.mdx
@@ -38,24 +38,20 @@ If you choose the second option, we will proceed to configure the different serv
 
 To start, we need to configure a Docker registry, as when deploying an application, you need a registry to deploy and download the application image on the other servers.
 
-We offer two ways to configure a registry:
-
-1. **External Registry**: Use any registry you want.
-2. **Self-Hosted Registry**: We create and configure a self-hosted registry for you.
-
 ### External Registry
 
-You can use any registry, such as Docker Hub, DigitalOcean Spaces, ECR, or your choice. Make sure to enter the correct credentials and test the connection before adding the registry.
+You can use any external registry of your choice. Here are some popular options:
 
-### Self-Hosted Registry
+1. **Docker Hub** - Free tier available, easy to set up
+2. **GitHub Container Registry (ghcr.io)** - Free for public repositories
+3. **DigitalOcean Container Registry** - Simple setup with good integration
+4. **Amazon ECR** - AWS's managed container registry
+5. **Google Container Registry** - Google Cloud's managed registry
+6. **Azure Container Registry** - Microsoft's managed registry
 
-We will ask you for three things:
+Make sure to enter the correct credentials and test the connection before adding the registry to your cluster configuration.
 
-1. A user.
-2. A password.
-3. A domain. Ensure this domain is pointing to the dokploy VPS.
-
-Once set up, the Cluster section will be unlocked.
+Once configured, the Cluster section will be unlocked.
 
 ## Understanding Docker Swarm
 


### PR DESCRIPTION
## Description
This PR fixes the documentation issue where the cluster setup guide mentioned a self-hosted registry feature that was previously removed from Dokploy. The documentation was misleading users by suggesting that Dokploy would automatically create and configure a self-hosted registry.

## Changes Made
- **Removed** the "Self-Hosted Registry" section that mentioned automatic setup
- **Updated** the registry configuration section to focus only on external registries
- **Added** comprehensive recommendations for easy-to-setup external registries:
  - Docker Hub (free tier)
  - GitHub Container Registry (ghcr.io)
  - DigitalOcean Container Registry
  - Amazon ECR
  - Google Container Registry
  - Azure Container Registry

## Problem Solved
- Fixes the issue where users expected an auto-setup self-hosted registry feature
- Provides clear guidance on which external registries to use
- Removes confusion about non-existent functionality

## Testing
- [x] Documentation builds successfully
- [x] All registry recommendations are accurate and up-to-date
- [x] No broken links or references

Closes #[2575]

<img width="1189" height="631" alt="Screenshot 2025-09-11 at 7 17 44 PM" src="https://github.com/user-attachments/assets/705285e5-030d-4f02-9947-b60a1c79a14b" />
