### PR TITLE
fix(docs): correct typo in saveGitProvider API endpoint name

### DIFF
--- a/apps/docs/api.json
+++ b/apps/docs/api.json
@@ -1898,9 +1898,9 @@
 				}
 			}
 		},
-		"/application.saveGitProdiver": {
+		"/application.saveGitProvider": {
 			"post": {
-				"operationId": "application-saveGitProdiver",
+				"operationId": "application-saveGitProvider",
 				"tags": ["application"],
 				"security": [
 					{

--- a/apps/docs/content/docs/api/generated/reference-application.mdx
+++ b/apps/docs/content/docs/api/generated/reference-application.mdx
@@ -43,8 +43,8 @@ _openapi:
       title: Application save Docker Provider
       url: '#application-save-docker-provider'
     - depth: 2
-      title: Application save Git Prodiver
-      url: '#application-save-git-prodiver'
+      title: Application save Git Provider
+      url: '#application-save-git-provider'
     - depth: 2
       title: Application mark Running
       url: '#application-mark-running'
@@ -97,8 +97,8 @@ _openapi:
         id: application-save-bitbucket-provider
       - content: Application save Docker Provider
         id: application-save-docker-provider
-      - content: Application save Git Prodiver
-        id: application-save-git-prodiver
+      - content: Application save Git Provider
+        id: application-save-git-provider
       - content: Application mark Running
         id: application-mark-running
       - content: Application update
@@ -118,4 +118,4 @@ _openapi:
     contents: []
 ---
 
-<APIPage document={"./api.json"} operations={[{"method":"post","path":"/application.create"},{"method":"get","path":"/application.one"},{"method":"post","path":"/application.reload"},{"method":"post","path":"/application.delete"},{"method":"post","path":"/application.stop"},{"method":"post","path":"/application.start"},{"method":"post","path":"/application.redeploy"},{"method":"post","path":"/application.saveEnvironment"},{"method":"post","path":"/application.saveBuildType"},{"method":"post","path":"/application.saveGithubProvider"},{"method":"post","path":"/application.saveGitlabProvider"},{"method":"post","path":"/application.saveBitbucketProvider"},{"method":"post","path":"/application.saveDockerProvider"},{"method":"post","path":"/application.saveGitProdiver"},{"method":"post","path":"/application.markRunning"},{"method":"post","path":"/application.update"},{"method":"post","path":"/application.refreshToken"},{"method":"post","path":"/application.deploy"},{"method":"post","path":"/application.cleanQueues"},{"method":"get","path":"/application.readTraefikConfig"},{"method":"post","path":"/application.updateTraefikConfig"},{"method":"get","path":"/application.readAppMonitoring"}]} hasHead={true} />
+<APIPage document={"./api.json"} operations={[{"method":"post","path":"/application.create"},{"method":"get","path":"/application.one"},{"method":"post","path":"/application.reload"},{"method":"post","path":"/application.delete"},{"method":"post","path":"/application.stop"},{"method":"post","path":"/application.start"},{"method":"post","path":"/application.redeploy"},{"method":"post","path":"/application.saveEnvironment"},{"method":"post","path":"/application.saveBuildType"},{"method":"post","path":"/application.saveGithubProvider"},{"method":"post","path":"/application.saveGitlabProvider"},{"method":"post","path":"/application.saveBitbucketProvider"},{"method":"post","path":"/application.saveDockerProvider"},{"method":"post","path":"/application.saveGitProvider"},{"method":"post","path":"/application.markRunning"},{"method":"post","path":"/application.update"},{"method":"post","path":"/application.refreshToken"},{"method":"post","path":"/application.deploy"},{"method":"post","path":"/application.cleanQueues"},{"method":"get","path":"/application.readTraefikConfig"},{"method":"post","path":"/application.updateTraefikConfig"},{"method":"get","path":"/application.readAppMonitoring"}]} hasHead={true} />

--- a/apps/docs/content/docs/api/reference-application.mdx
+++ b/apps/docs/content/docs/api/reference-application.mdx
@@ -43,8 +43,8 @@ _openapi:
       title: Application save Docker Provider
       url: '#application-save-docker-provider'
     - depth: 2
-      title: Application save Git Prodiver
-      url: '#application-save-git-prodiver'
+      title: Application save Git Provider
+      url: '#application-save-git-provider'
     - depth: 2
       title: Application mark Running
       url: '#application-mark-running'
@@ -97,8 +97,8 @@ _openapi:
         id: application-save-bitbucket-provider
       - content: Application save Docker Provider
         id: application-save-docker-provider
-      - content: Application save Git Prodiver
-        id: application-save-git-prodiver
+      - content: Application save Git Provider
+        id: application-save-git-provider
       - content: Application mark Running
         id: application-mark-running
       - content: Application update
@@ -118,4 +118,4 @@ _openapi:
     contents: []
 ---
 
-<APIPage document={"./api.json"} operations={[{"method":"post","path":"/application.create"},{"method":"get","path":"/application.one"},{"method":"post","path":"/application.reload"},{"method":"post","path":"/application.delete"},{"method":"post","path":"/application.stop"},{"method":"post","path":"/application.start"},{"method":"post","path":"/application.redeploy"},{"method":"post","path":"/application.saveEnvironment"},{"method":"post","path":"/application.saveBuildType"},{"method":"post","path":"/application.saveGithubProvider"},{"method":"post","path":"/application.saveGitlabProvider"},{"method":"post","path":"/application.saveBitbucketProvider"},{"method":"post","path":"/application.saveDockerProvider"},{"method":"post","path":"/application.saveGitProdiver"},{"method":"post","path":"/application.markRunning"},{"method":"post","path":"/application.update"},{"method":"post","path":"/application.refreshToken"},{"method":"post","path":"/application.deploy"},{"method":"post","path":"/application.cleanQueues"},{"method":"get","path":"/application.readTraefikConfig"},{"method":"post","path":"/application.updateTraefikConfig"},{"method":"get","path":"/application.readAppMonitoring"}]} hasHead={true} />
+<APIPage document={"./api.json"} operations={[{"method":"post","path":"/application.create"},{"method":"get","path":"/application.one"},{"method":"post","path":"/application.reload"},{"method":"post","path":"/application.delete"},{"method":"post","path":"/application.stop"},{"method":"post","path":"/application.start"},{"method":"post","path":"/application.redeploy"},{"method":"post","path":"/application.saveEnvironment"},{"method":"post","path":"/application.saveBuildType"},{"method":"post","path":"/application.saveGithubProvider"},{"method":"post","path":"/application.saveGitlabProvider"},{"method":"post","path":"/application.saveBitbucketProvider"},{"method":"post","path":"/application.saveDockerProvider"},{"method":"post","path":"/application.saveGitProvider"},{"method":"post","path":"/application.markRunning"},{"method":"post","path":"/application.update"},{"method":"post","path":"/application.refreshToken"},{"method":"post","path":"/application.deploy"},{"method":"post","path":"/application.cleanQueues"},{"method":"get","path":"/application.readTraefikConfig"},{"method":"post","path":"/application.updateTraefikConfig"},{"method":"get","path":"/application.readAppMonitoring"}]} hasHead={true} />


### PR DESCRIPTION
## Description
Fixed a typo in the API documentation where "saveGitProdiver" was misspelled as "saveGitProvider" across multiple documentation files. This ensures consistency with the actual codebase implementation and prevents confusion for developers using the API documentation.

## Changes Made
- **API Documentation**: Updated endpoint path and operation ID in `api.json`
- **Reference Documentation**: Corrected references in `reference-application.mdx` files
- **Table of Contents**: Updated structured data sections to reflect the correct naming

## Files Modified
- `apps/docs/api.json`
- `apps/docs/content/docs/api/generated/reference-application.mdx`
- `apps/docs/content/docs/api/reference-application.mdx`

## Impact
- ✅ Improves API documentation accuracy
- ✅ Prevents developer confusion when using the API
- ✅ Maintains consistency between codebase and documentation
- ✅ No breaking changes to functionality

## Testing
- [x] Verified all documentation references are now consistent
- [x] Confirmed the corrected endpoint name matches the actual implementation

---

**Commit in main repo**: `fix: correct typo in saveGitProvider function name`