### PR TITLE
docs: add Google Cloud Storage for S3 Destination

### DIFF
--- a/apps/docs/content/docs/core/(S3-Destinations)/cloud-storage.mdx
+++ b/apps/docs/content/docs/core/(S3-Destinations)/cloud-storage.mdx
@@ -1,0 +1,27 @@
+---
+title: Google Cloud Storage
+description: 'Configure Google Cloud Storage buckets for backup storage. This includes setting up access keys, secret keys, bucket names, regions, and endpoints.'
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+
+Google Cloud Storage provides a simple and cost-effective way to store and retrieve data. It is a cloud-based service that allows you to store and retrieve data from anywhere in the world. This is a great option for storing backups, as it is easy to set up and manage.
+
+1. Navigate to the Cloud Storage console and create a new bucket with preferred name.
+2. Navigate to the IAM & Admin and create a new service account. Assign a role `Storage Admin` to the service account.
+3. Return to Cloud Storage again, and click `Settings` on the left navigation menu.
+4. Click `Interoperability` tab. This is where you will create Amazon S3-compatible ID and access keys.
+5. Copy the value in `Storage URI`. You will need this for the Endpoint value in Dokploy.
+6. Under `Service account HMAC`, click `Create a key for a service account`. Select the service account you created earlier and click `Create`. You will get an Access Key and a Secret Key.
+
+Now copy the following variables:
+
+| (from) Cloud Storage | (to) Dokploy        | Example value                                                        |
+|---------------------|---------------------|---------------------------------------------------------------------|
+| `Access Key`        | `Access Key ID`     | `f3811c6d27415a9s6cv943b6743ad784`                                   |
+| `Secret`            | `Secret Access Key` | `aa55ee40b4049e93b7252bf698408cc22a3c2856d2530s7c1cb7670e318f15e58`  |
+| `Location`          | `Region`            | `us-central1, etc` it will depend on the region you are using.       |
+| `Endpoint`          | `Endpoint`          | `https://storage.googleapis.com`. The value in `Storage URI`.       |
+| `Bucket Name`       | `Bucket`            | `dokploy-backups` use the name of the bucket you created.            |
+
+Test the connection and you should see a success message.


### PR DESCRIPTION
Hi, first of all thanks for this awesome project! I really like it and use it for my hobby projects.

This PR adds a new sub page under S3 Destination. It describes the instruction on how to set up Google Cloud Storage and Dokploy to use the storage service as an S3 destination for backup.