### PR TITLE
feat:Fix API documentation alignment: Replace projectId with environmentId

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function HomePage() {
+	// Redirect to the docs core page when accessing the root
+	redirect("/docs/core");
+}


### PR DESCRIPTION
## Problem
API documentation at `/docs/api/reference-*` was showing `projectId` in request schemas while Swagger documentation correctly showed `environmentId`, causing inconsistency.

## Solution
Updated `apps/docs/api.json` to replace `projectId` with `environmentId` for all database service endpoints:
- `/postgres.create`
- `/mysql.create` 
- `/redis.create`
- `/mongo.create`
- `/mariadb.create`

## Changes
- Updated field definitions in OpenAPI schema
- Updated required fields arrays
- Ensures consistency between Swagger and API docs

<img width="1134" height="551" alt="Screenshot 2025-10-21 at 12 58 56 PM" src="https://github.com/user-attachments/assets/28a6f1d0-a328-4a52-afd5-d2ebad5760dd" />


Fixes #2855