### PR TITLE
feat: Fix API documentation alignment: Replace projectId with environmentId

### DIFF
--- a/apps/docs/api.json
+++ b/apps/docs/api.json
@@ -2713,7 +2713,7 @@
 										"type": "string",
 										"default": "mysql:8"
 									},
-									"projectId": {
+									"environmentId": {
 										"type": "string"
 									},
 									"description": {
@@ -2742,7 +2742,7 @@
 								"required": [
 									"name",
 									"appName",
-									"projectId",
+									"environmentId",
 									"databaseName",
 									"databaseUser",
 									"databasePassword",
@@ -3282,7 +3282,7 @@
 										"type": "string",
 										"default": "postgres:15"
 									},
-									"projectId": {
+									"environmentId": {
 										"type": "string"
 									},
 									"description": {
@@ -3300,7 +3300,7 @@
 									"databaseName",
 									"databaseUser",
 									"databasePassword",
-									"projectId"
+									"environmentId"
 								],
 								"additionalProperties": false
 							}
@@ -3824,7 +3824,7 @@
 										"type": "string",
 										"default": "redis:8"
 									},
-									"projectId": {
+									"environmentId": {
 										"type": "string"
 									},
 									"description": {
@@ -3840,7 +3840,7 @@
 									"name",
 									"appName",
 									"databasePassword",
-									"projectId"
+									"environmentId"
 								],
 								"additionalProperties": false
 							}
@@ -4355,7 +4355,7 @@
 										"type": "string",
 										"default": "mongo:15"
 									},
-									"projectId": {
+									"environmentId": {
 										"type": "string"
 									},
 									"description": {
@@ -4377,7 +4377,7 @@
 								"required": [
 									"name",
 									"appName",
-									"projectId",
+									"environmentId",
 									"databaseUser",
 									"databasePassword"
 								],
@@ -4901,7 +4901,7 @@
 									"databaseRootPassword": {
 										"type": "string"
 									},
-									"projectId": {
+									"environmentId": {
 										"type": "string"
 									},
 									"description": {
@@ -4928,7 +4928,7 @@
 									"name",
 									"appName",
 									"databaseRootPassword",
-									"projectId",
+									"environmentId",
 									"databaseName",
 									"databaseUser",
 									"databasePassword"


### PR DESCRIPTION
## Problem
API documentation at `/docs/api/reference-*` was showing `projectId` in request schemas while Swagger documentation correctly showed `environmentId`, causing inconsistency.

## Solution
Updated `apps/docs/api.json` to replace `projectId` with `environmentId` for all database service endpoints:
- `/postgres.create`
- `/mysql.create` 
- `/redis.create`
- `/mongo.create`
- `/mariadb.create`

## Changes
- Updated field definitions in OpenAPI schema
- Updated required fields arrays
- Ensures consistency between Swagger and API docs

<img width="1134" height="551" alt="Screenshot 2025-10-21 at 12 58 56 PM" src="https://github.com/user-attachments/assets/7b704734-c960-4d7a-828a-f9c64de5b6c0" />


Fixes #2855