### PR TITLE
chore: bump traefik to v3.6.1

### DIFF
--- a/apps/docs/content/docs/core/manual-installation.mdx
+++ b/apps/docs/content/docs/core/manual-installation.mdx
@@ -143,7 +143,7 @@ install_dokploy() {
     --mount type=volume,source=redis-data-volume,target=/data \
     redis:7
 
-    docker pull traefik:v3.5.0
+    docker pull traefik:v3.6.1
     docker pull dokploy/dokploy:latest
 
     # Installation
@@ -171,7 +171,7 @@ install_dokploy() {
         -p 80:80/tcp \
         -p 443:443/tcp \
         -p 443:443/udp \
-        traefik:v3.5.0
+        traefik:v3.6.1
 
     docker network connect dokploy-network dokploy-traefik
 
@@ -187,7 +187,7 @@ install_dokploy() {
     #     --publish mode=host,published=443,target=443 \
     #     --publish mode=host,published=80,target=80 \
     #     --publish mode=host,published=443,target=443,protocol=udp \
-    #     traefik:v3.5.0
+    #     traefik:v3.6.1
 
     GREEN="\033[0;32m"
     YELLOW="\033[1;33m"

--- a/apps/docs/content/docs/core/troubleshooting.mdx
+++ b/apps/docs/content/docs/core/troubleshooting.mdx
@@ -432,7 +432,7 @@ docker run -d \
     -p 80:80/tcp \
     -p 443:443/tcp \
     -p 443:443/udp \
-    traefik:v3.5.0
+    traefik:v3.6.1
 
 docker network connect dokploy-network dokploy-traefik
 
@@ -449,7 +449,7 @@ docker run -d \
     -p 80:80/tcp \
     -p 443:443/tcp \
     -p 443:443/udp \
-    traefik:v3.5.0
+    traefik:v3.6.1
 ```
 
 Remove the dokploy service:

--- a/apps/website/public/canary.sh
+++ b/apps/website/public/canary.sh
@@ -160,7 +160,7 @@ install_dokploy() {
     -p 80:80/tcp \
     -p 443:443/tcp \
     -p 443:443/udp \
-    traefik:v3.5.0
+    traefik:v3.6.1
 
     docker network connect dokploy-network dokploy-traefik
 
@@ -175,7 +175,7 @@ install_dokploy() {
     #     --publish mode=host,published=443,target=443 \
     #     --publish mode=host,published=80,target=80 \
     #     --publish mode=host,published=443,target=443,protocol=udp \
-    #     traefik:v3.5.0
+    #     traefik:v3.6.1
 
     GREEN="\033[0;32m"
     YELLOW="\033[1;33m"

--- a/apps/website/public/feature.sh
+++ b/apps/website/public/feature.sh
@@ -162,7 +162,7 @@ install_dokploy() {
     -p 80:80/tcp \
     -p 443:443/tcp \
     -p 443:443/udp \
-    traefik:v3.5.0
+    traefik:v3.6.1
 
     docker network connect dokploy-network dokploy-traefik
 
@@ -177,7 +177,7 @@ install_dokploy() {
     #     --publish mode=host,published=443,target=443 \
     #     --publish mode=host,published=80,target=80 \
     #     --publish mode=host,published=443,target=443,protocol=udp \
-    #     traefik:v3.5.0
+    #     traefik:v3.6.1
 
 
     GREEN="\033[0;32m"

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -189,7 +189,7 @@ install_dokploy() {
         -p 80:80/tcp \
         -p 443:443/tcp \
         -p 443:443/udp \
-        traefik:v3.5.0
+        traefik:v3.6.1
     
     docker network connect dokploy-network dokploy-traefik
 
@@ -205,7 +205,7 @@ install_dokploy() {
     #     --publish mode=host,published=443,target=443 \
     #     --publish mode=host,published=80,target=80 \
     #     --publish mode=host,published=443,target=443,protocol=udp \
-    #     traefik:v3.5.0
+    #     traefik:v3.6.1
 
     GREEN="\033[0;32m"
     YELLOW="\033[1;33m"


### PR DESCRIPTION
## Description
As requested by [this issue](https://github.com/Dokploy/dokploy/issues/2990) in the Dokploy app repository, Traefik need to be updated to handle latest Docker versions

PR for Dokploy app is [available here](https://github.com/Dokploy/dokploy/pull/3000). Everything is explain there

## Related issue
closes #83 