### PR TITLE
Update API endpoint in Dokploy deployment instructions

### DIFF
--- a/apps/docs/content/docs/core/applications/going-production.mdx
+++ b/apps/docs/content/docs/core/applications/going-production.mdx
@@ -158,9 +158,7 @@ jobs:
             -H 'x-api-key: YOUR-GENERATED-API-KEY' \
             -H 'Content-Type: application/json' \
             -d '{
-                "json":{
-                    "applicationId": "YOUR-APPLICATION-ID"
-                }
+                 "applicationId": "YOUR-APPLICATION-ID"
             }'
 ```
 


### PR DESCRIPTION
Using the endpoint that cointains `/trpc` results in "HTTP Status: 308", which `curl` doesn't follow by default. That result on the API call being ignored by Dokploy.

edit: just realized the payload was not compatible due to the nesting inside the `json` key. Fixed in a new commit.