### PR TITLE
feat: allow to declare custom db credentials in install scripts

### DIFF
--- a/apps/docs/content/docs/core/manual-installation.mdx
+++ b/apps/docs/content/docs/core/manual-installation.mdx
@@ -134,13 +134,17 @@ install_dokploy() {
 
     chmod 777 /etc/dokploy
 
+    postgres_user="${POSTGRES_USER:-dokploy}"
+    postgres_db="${POSTGRES_DB:-dokploy}"
+    postgres_password="${POSTGRES_PASSWORD:-$(openssl rand --hex 32)}"
+
     docker service create \
     --name dokploy-postgres \
     --constraint 'node.role==manager' \
     --network dokploy-network \
-    --env POSTGRES_USER=dokploy \
-    --env POSTGRES_DB=dokploy \
-    --env POSTGRES_PASSWORD=amukds4wi9001583845717ad2 \
+    --env POSTGRES_USER=${postgres_user} \
+    --env POSTGRES_DB=${postgres_db} \
+    --env POSTGRES_PASSWORD=${postgres_password} \
     --mount type=volume,source=dokploy-postgres,target=/var/lib/postgresql/data \
     postgres:16
 
@@ -159,6 +163,7 @@ install_dokploy() {
       --name dokploy \
       --replicas 1 \
       --network dokploy-network \
+      --env DATABASE_URL="postgres://${postgres_user}:${postgres_password}@dokploy-postgres:5432/${postgres_db}" \
       --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
       --mount type=bind,source=/etc/dokploy,target=/etc/dokploy \
       --mount type=volume,source=dokploy,target=/root/.docker \

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -199,13 +199,21 @@ install_dokploy() {
 
     chmod 777 /etc/dokploy
 
+    # Allow to specify a custom username, password and database name for PostgreSQL
+    # Example: export POSTGRES_PASSWORD=replace-me-with-a-secure-password
+    # If no username and/or database name is specified, "dokploy" is used.
+    # If no password is specified, a random password will be generated.
+    postgres_user="${POSTGRES_USER:-dokploy}"
+    postgres_db="${POSTGRES_DB:-dokploy}"
+    postgres_password="${POSTGRES_PASSWORD:-$(openssl rand --hex 32)}"
+
     docker service create \
     --name dokploy-postgres \
     --constraint 'node.role==manager' \
     --network dokploy-network \
-    --env POSTGRES_USER=dokploy \
-    --env POSTGRES_DB=dokploy \
-    --env POSTGRES_PASSWORD=amukds4wi9001583845717ad2 \
+    --env POSTGRES_USER=${postgres_user} \
+    --env POSTGRES_DB=${postgres_db} \
+    --env POSTGRES_PASSWORD=${postgres_password} \
     --mount type=volume,source=dokploy-postgres,target=/var/lib/postgresql/data \
     $endpoint_mode \
     postgres:16
@@ -229,6 +237,7 @@ install_dokploy() {
       --name dokploy \
       --replicas 1 \
       --network dokploy-network \
+      --env DATABASE_URL="postgres://${postgres_user}:${postgres_password}@dokploy-postgres:5432/${postgres_db}" \
       --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
       --mount type=bind,source=/etc/dokploy,target=/etc/dokploy \
       --mount type=volume,source=dokploy,target=/root/.docker \


### PR DESCRIPTION
I removed the hard coded database credentials from the install.sh script and the script included in the manual-installations docs page. Instead I created three new variables (`postgres_user`, `postgres_db`, `postgres_password`) to declare the credentials, which then will be added as `DATABASE_URL` to the dokploy container.

If no password is defined by the user a random one will be generated with `openssl rand --hex 32`.

I tested the script on a blank debian 13 server and it worked as expected.

This increases the security of every new Dokploy installation by using a unique password.

This commit solves the issue Dokploy/dokploy#3384 of the dokploy repo.