### PR TITLE
Remove legacy DATABASE_URL env

### DIFF
--- a/apps/website/public/security/0.26.6.sh
+++ b/apps/website/public/security/0.26.6.sh
@@ -95,6 +95,7 @@ echo "🔄 Updating Dokploy service..."
 docker service update \
     --secret-add source=dokploy_postgres_password,target=/run/secrets/postgres_password \
     --env-add POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
+    --env-rm DATABASE_URL \
     dokploy
 
 echo "⏳ Waiting for services to restart..."


### PR DESCRIPTION
Migrating to v0.26.7 and running the security script causes the dokploy container to error  as the legacy [DATABASE_URL ](https://github.com/Dokploy/dokploy/blob/fa201a5a963e6594c747ba867d61637929c2f925/packages/server/src/db/constants.ts#L22) overrides the new postgres password

The script will remove the old env now 