### PR TITLE
docs: Adds warning for env injection in docker-compose

### DIFF
--- a/apps/docs/content/docs/core/docker-compose/index.mdx
+++ b/apps/docs/content/docs/core/docker-compose/index.mdx
@@ -23,13 +23,25 @@ Configure the source of your code, the way your application is built, and also m
 The code editor in Dokploy allows you to define environment variables for your Docker Compose deployment. By default, Dokploy saves these variables to a `.env` file in the same directory as your `docker-compose.yml`.
 
 <Callout type="warning">
-Environment variables set in the UI are written to the `.env` file, but are **not automatically injected into containers**. To pass variables into a service, use the `env_file` option in your `docker-compose.yml`:
+Environment variables set in the UI are written to the `.env` file, but are **not automatically injected into containers**. You have two options:
+
+**1. Inject all variables** — Use the `env_file` option in your `docker-compose.yml` to load every variable from the `.env` file into the container:
 
 ```yaml
 services:
   app:
     env_file:
       - .env
+```
+
+**2. Use specific variables** — Reference only the variables you need using the standard `${VAR_NAME}` syntax in your `docker-compose.yml`:
+
+```yaml
+services:
+  app:
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - API_KEY=${API_KEY}
 ```
 </Callout>
 


### PR DESCRIPTION
This PR updates the documentation to make it clear that environment variables set in the Dokploy UI are not automatically injected into containers, unlike commercial alternatives. The has been widely confusing:

- https://github.com/Dokploy/dokploy/discussions/2088
- https://github.com/Dokploy/dokploy/issues/385

This docs change serves as a *temporary* solution to the above confusion, allowing users can find an answer on the official docs rather than hunting down closed GitHub issues/discussions. However, a complete fix should include:
1. A warning in UI on the variables tab; Or, preferably, 
2. Automatic injection of the variables by modifying the `docker-compose` file (this is already done for Traefik labels, so I'm unsure why it couldn't be done here)

Both of which have been suggested in the issues listed above.

Screenshot of docs fix:

<img width="966" height="377" alt="Screenshot 2026-02-10 at 20 15 05" src="https://github.com/user-attachments/assets/d1659cfa-0d77-49cb-84e5-54084e1af097" />
