### PR TITLE
fix: Improve release tag extraction to avoid issues with some curl version

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -16,12 +16,16 @@ detect_version() {
         echo "Detecting latest stable version from GitHub..." >&2
         
         # Try to get latest release from GitHub by following redirects
-        version=$(curl -fsSL -o /dev/null -w '%{url_effective}\n' \
-            https://github.com/dokploy/dokploy/releases/latest 2>/dev/null | \
-            sed 's#.*/tag/##')
+        effective_url=$(curl -fsSL -o /dev/null -w '%{url_effective}\n' \
+            https://github.com/dokploy/dokploy/releases/latest 2>/dev/null)
         
-        # Fallback to latest tag if detection fails
-        if [ -z "$version" ]; then
+        # Extract tag from URL (format: .../releases/tag/v0.x.x)
+        if echo "$effective_url" | grep -q '/tag/'; then
+            version=$(echo "$effective_url" | sed 's#.*/tag/##')
+        fi
+        
+        # Validate version looks like a tag (starts with 'v' or is a valid semver)
+        if [ -z "$version" ] || echo "$version" | grep -q '^http'; then
             echo "Warning: Could not detect latest version from GitHub, using fallback version latest" >&2
             version="latest"
         else


### PR DESCRIPTION
This PR is a fix linked to the following issue: https://github.com/Dokploy/website/issues/126

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved the release tag extraction logic in the installation script to be more robust across different `curl` versions. The change splits the version detection into two steps: first storing the effective URL from the GitHub redirect, then validating and extracting the tag only if `/tag/` is present in the URL. Additionally adds validation to detect if the extraction failed by checking if the version string still contains `http`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes improve robustness of version detection without introducing new logic or modifying behavior in success cases. The refactoring adds defensive checks that gracefully fall back to the existing "latest" fallback on failure. The changes are well-scoped, backward-compatible, and address a specific compatibility issue with certain curl versions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->