### PR TITLE
docs: Add Mattermost as a notification provider and update related documentation

### DIFF
--- a/apps/docs/content/docs/core/(Notifications)/mattermost.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/mattermost.mdx
@@ -1,0 +1,28 @@
+---
+title: Mattermost
+description: 'Configure mattermost notifications for your applications.'
+---
+
+
+Mattermost notifications are a great way to stay up to date with important events in your Dokploy panel. You can choose to receive notifications for specific events or all events.
+
+## Mattermost Notifications
+
+To start receiving mattermost notifications, you need to fill the form with the following details:
+
+- **Name**: Enter any name you want.
+- **Webhook URL**: Enter the webhook URL. eg. `https://your-mattermost.com/hooks/xxx-generatedkey-xxx`
+- **Channel**: Enter the channel name that you want to send the notifications to.
+- **Username**: Enter the username that you want to send the notifications by.
+
+To Setup the mattermost notifications, follow these steps:
+
+
+1. Go to `https://your-mattermost.com/organization_name/integrations/incoming_webhooks` and click on `Add Incoming Webhook`.
+2. Enter title, description and select the channel that you want to send the notifications to.
+3. Click on `Save`.
+4. Copy the `Webhook URL`.
+5. Go to Dokploy `Notifications` and select `Mattermost` as the notification provider.
+6. Use the `Webhook URL` you copied in the previous step.
+7. In Channel section, select the channel that you want to send the notifications to.
+8. Click on `Create` to save the notification.

--- a/apps/docs/content/docs/core/(Notifications)/meta.json
+++ b/apps/docs/content/docs/core/(Notifications)/meta.json
@@ -3,6 +3,7 @@
 	"pages": [
 		"overview",
 		"slack",
+		"mattermost",
 		"telegram",
 		"discord",
 		"lark",

--- a/apps/docs/content/docs/core/(Notifications)/overview.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/overview.mdx
@@ -23,13 +23,14 @@ You can select which actions trigger notifications:
 Dokploy supports the following notification providers:
 
 1. **Slack**: Slack is a platform for team communication and collaboration.
-2. **Telegram**: Telegram is a messaging platform that allows users to send and receive messages.
-3. **Discord**: Discord is generally used for communication between users in a chat or voice channel.
-4. **Lark**: Lark is a collaboration platform that provides messaging and team communication features.
-5. **Email**: Email is a popular method for sending messages to a group of recipients.
-6. **Resend**: Resend is a modern email API for developers to send transactional emails.
-7. **Gotify**: Gotify is a self-hosted push notification service.
-8. **Ntfy**: Ntfy is a simple HTTP-based pub-sub notification service.
-8. **Pushover**: Pushover is a service for sending real-time notifications to Android, iOS, and desktop devices.
-9. **Webhook**: Webhook is a generic webhook notification service.
+2. **Mattermost**: Mattermost is an open source platform for team communication and collaboration.
+3. **Telegram**: Telegram is a messaging platform that allows users to send and receive messages.
+4. **Discord**: Discord is generally used for communication between users in a chat or voice channel.
+5. **Lark**: Lark is a collaboration platform that provides messaging and team communication features.
+6. **Email**: Email is a popular method for sending messages to a group of recipients.
+7. **Resend**: Resend is a modern email API for developers to send transactional emails.
+8. **Gotify**: Gotify is a self-hosted push notification service.
+9. **Ntfy**: Ntfy is a simple HTTP-based pub-sub notification service.
+10. **Pushover**: Pushover is a service for sending real-time notifications to Android, iOS, and desktop devices.
+11. **Webhook**: Webhook is a generic webhook notification service.
 


### PR DESCRIPTION
- Included Mattermost in the list of supported notification providers in meta.json.
- Updated overview.mdx to describe Mattermost notifications.
- Created a new mattermost.mdx file with detailed setup instructions for Mattermost notifications.

Docs for Dokploy/dokploy#2728

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Mattermost as a new notification provider with complete documentation including setup instructions, webhook configuration, and channel selection. The changes follow the existing documentation pattern used for other notification providers like Slack and Discord.

- Added `mattermost.mdx` documentation file with setup instructions
- Updated `meta.json` to include Mattermost in the navigation
- Updated `overview.mdx` to list Mattermost as a supported provider

**Issues found:**
- Duplicate step numbering in both `mattermost.mdx` (step 7 appears twice) and `overview.mdx` (item 8 appears twice)
- Grammar errors: "For start receiving" should be "To start receiving", and "a open source" should be "an open source"

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the minor syntax and numbering issues
- The PR correctly implements documentation for a new notification provider following existing patterns. The only issues are minor syntax errors (duplicate step numbering and grammar mistakes) that should be fixed before merging. No logical errors or security concerns.
- All files have minor syntax issues that need correction before merging

<sub>Last reviewed commit: 579c69c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->