### PR TITLE
fix: get latest version

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -16,9 +16,7 @@ detect_version() {
         echo "Detecting latest stable version from GitHub..." >&2
         
         # Try to get latest release from GitHub by following redirects
-        version=$(curl -fsSL -o /dev/null -w '%{url_effective}\n' \
-            https://github.com/dokploy/dokploy/releases/latest 2>/dev/null | \
-            sed 's#.*/tag/##')
+        version=$(curl -s https://api.github.com/repos/dokploy/dokploy/releases/latest | grep "\"tag_name\":" | cut -d "\"" -f 4)
         
         # Fallback to latest tag if detection fails
         if [ -z "$version" ]; then


### PR DESCRIPTION
The previous GitHub release request wasn't stable, and I had issues with that. I've made it more stable.

<img width="1592" height="106" alt="image" src="https://github.com/user-attachments/assets/1741e5f6-6058-4301-8e17-335270c15f63" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed GitHub release version detection from redirect-following to API endpoint parsing. While the API approach may seem more direct, it introduces **critical issues**:

- **Rate limiting**: GitHub API has strict limits (60 requests/hour unauthenticated) that will cause failures for popular installation scripts
- **Missing error handling**: Removed `-f` flag means HTTP errors won't trigger the fallback mechanism properly
- **Fragile JSON parsing**: Using `grep | cut` instead of a proper JSON parser risks breaking with formatting changes

The previous redirect-following method was more robust as it didn't count against API limits and was the recommended approach for public installation scripts.

<h3>Confidence Score: 1/5</h3>

- This PR introduces critical reliability issues that will cause installation failures under normal usage conditions
- The GitHub API rate limiting issue alone makes this change problematic for a public installation script that could be run frequently. Combined with missing error handling and fragile JSON parsing, this change reduces stability rather than improving it.
- apps/website/public/install.sh requires immediate attention - the version detection logic needs to be reverted or significantly improved

<sub>Last reviewed commit: 59c90c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->