### PR TITLE
fix: support macOS installation and add swarm init guidance

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -190,7 +190,7 @@ install_dokploy() {
     get_private_ip() {
         if [ "$IS_MAC" = true ]; then
             # macOS: Use osascript for reliable local IP
-            osascript -e "IPv4 address of (system info)" 2>/dev/null || echo "127.0.0.1"
+            ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "127.0.0.1"
         else
             ip addr show | grep -E "inet (192\.168\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.)" | head -n1 | awk '{print $2}' | cut -d/ -f1
         fi

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -8,6 +8,13 @@
 # Usage with bash: DOKPLOY_VERSION=canary bash install.sh
 # Usage with bash: DOKPLOY_VERSION=latest bash install.sh
 # Usage with bash: bash install.sh (detects latest stable version)
+
+# Detect OS
+IS_MAC=false
+if [ "$(uname)" = "Darwin" ]; then
+    IS_MAC=true
+fi
+
 detect_version() {
     local version="${DOKPLOY_VERSION}"
     
@@ -78,6 +85,15 @@ generate_random_password() {
     echo "$password"
 }
 
+check_port() {
+    local port=$1
+    if [ "$IS_MAC" = true ]; then
+        lsof -Pi :$port -sTCP:LISTEN >/dev/null 2>&1
+    else
+        ss -tulnp | grep ":$port " >/dev/null 2>&1
+    fi
+}
+
 install_dokploy() {
     # Detect version tag
     VERSION_TAG=$(detect_version)
@@ -89,36 +105,19 @@ install_dokploy() {
         exit 1
     fi
 
-    # check if is Mac OS
-    if [ "$(uname)" = "Darwin" ]; then
-        echo "This script must be run on Linux" >&2
-        exit 1
-    fi
-
     # check if is running inside a container
     if [ -f /.dockerenv ]; then
         echo "This script must be run on Linux" >&2
         exit 1
     fi
 
-    # check if something is running on port 80
-    if ss -tulnp | grep ':80 ' >/dev/null; then
-        echo "Error: something is already running on port 80" >&2
-        exit 1
-    fi
-
-    # check if something is running on port 443
-    if ss -tulnp | grep ':443 ' >/dev/null; then
-        echo "Error: something is already running on port 443" >&2
-        exit 1
-    fi
-
-    # check if something is running on port 3000
-    if ss -tulnp | grep ':3000 ' >/dev/null; then
-        echo "Error: something is already running on port 3000" >&2
-        echo "Dokploy requires port 3000 to be available. Please stop any service using this port." >&2
-        exit 1
-    fi
+    # Port availability checks
+    for port in 80 443 3000; do
+        if check_port $port; then
+            echo "Error: something is already running on port $port" >&2
+            exit 1
+        fi
+    done
 
     command_exists() {
       command -v "$@" > /dev/null 2>&1
@@ -189,7 +188,12 @@ install_dokploy() {
     }
 
     get_private_ip() {
-        ip addr show | grep -E "inet (192\.168\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.)" | head -n1 | awk '{print $2}' | cut -d/ -f1
+        if [ "$IS_MAC" = true ]; then
+            # macOS: Use osascript for reliable local IP
+            osascript -e "IPv4 address of (system info)" 2>/dev/null || echo "127.0.0.1"
+        else
+            ip addr show | grep -E "inet (192\.168\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.)" | head -n1 | awk '{print $2}' | cut -d/ -f1
+        fi
     }
 
     advertise_addr="${ADVERTISE_ADDR:-$(get_private_ip)}"
@@ -216,6 +220,13 @@ install_dokploy() {
     
      if [ $? -ne 0 ]; then
         echo "Error: Failed to initialize Docker Swarm" >&2
+        if [ "$IS_MAC" = true ]; then
+            echo "" >&2
+            echo "💡 Tip for macOS users:" >&2
+            echo "Docker Desktop for Mac sometimes fails to recognize the host IP." >&2
+            echo "Please try running the script with a manual IP like this:" >&2
+            echo "sudo ADVERTISE_ADDR=127.0.0.1 bash install.sh" >&2
+        fi
         exit 1
     fi
 


### PR DESCRIPTION
Description:
This PR introduces support for macOS (Docker Desktop) to the installation script. Currently, the script is restricted to Linux, but many developers use macOS for testing and local development.

Key Improvements:
- OS Compatibility: Added IS_MAC detection to bypass Linux-only root checks.
- Port Checking: Replaced Linux-specific ss command with a portable check_port helper using lsof.
- User Guidance: Added a helpful tip to manually set ADVERTISE_ADDR=127.0.0.1 if Swarm initialization fails on Mac.

Related Issue: [dokploy/dokploy#2409](https://github.com/Dokploy/dokploy/issues/2409)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds macOS support to the Dokploy installation script by introducing OS detection, replacing Linux-specific commands with portable alternatives, and adding helpful guidance for Docker Swarm initialization issues.

**Key changes:**
- Added `IS_MAC` detection to identify macOS environments
- Replaced `ss` command with portable `check_port()` helper that uses `lsof` on macOS
- Added macOS-specific error guidance for Docker Swarm initialization failures
- Refactored port checking to use a loop instead of repeated code
- Made the script executable (file mode change)

**Issues found:**
- The `osascript` command for getting the private IP uses invalid AppleScript syntax and will always fail, falling back to `127.0.0.1`
- Root permission check still applies to macOS users, but Docker Desktop doesn't require root for most operations
- Error message at line 110 still says "must be run on Linux" despite adding macOS support

<h3>Confidence Score: 3/5</h3>

- This PR has good intentions but contains a critical bug that prevents the main feature from working correctly
- The PR makes sensible architectural changes (portable port checking, OS detection, helpful user guidance), but the core macOS IP detection feature is broken due to invalid AppleScript syntax. The script will still run due to the fallback, but it will always use `127.0.0.1` on macOS instead of detecting the actual private IP, which defeats part of the purpose of the PR. The other issues are minor (misleading error messages, unnecessary root check).
- The `get_private_ip()` function at line 193 requires immediate attention to fix the broken osascript command

<sub>Last reviewed commit: d98717a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->