### PR TITLE
docs: add tori-cli to goodies list

### DIFF
--- a/apps/docs/content/docs/core/goodies.mdx
+++ b/apps/docs/content/docs/core/goodies.mdx
@@ -12,5 +12,6 @@ description: "Dokploy has certain goodies that are external that can be used wit
 6. **Templates Collection** : Docker compose collection for Dokploy [Github](https://github.com/benbristow/dokploy-compose-templates)
 7. **Dokploy Port Updater**: Dokploy Port Updater [Github](https://github.com/clockradios/dokploy-port-updater)
 8. **Dokli TUI**: Dokli TUI [Github](https://github.com/jonykalavera/dokli)
+9. **Tori**: Lightweight Docker monitoring & alerting, single binary, SSH-only, no exposed ports [Github](https://github.com/thobiasn/tori-cli)
 
 Want to submit your own? [Submit a PR](https://github.com/Dokploy/website/blob/main/README.md)


### PR DESCRIPTION
Adds [Tori](https://github.com/thobiasn/tori-cli) to the goodies page. It's a lightweight Docker monitoring & alerting tool (single binary, SSH-only, no exposed ports) that complements Dokploy nicely for users who want server/container monitoring without a full Grafana+Prometheus stack.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Tori CLI to the goodies list - a lightweight Docker monitoring and alerting tool that complements Dokploy for users seeking simple container monitoring without complex infrastructure.

- The new entry is correctly numbered as item 9
- Minor formatting inconsistency: missing colon after tool name (compared to most other entries)
- Note: Pre-existing issue in file - items 5 and 6 both use number "5" (not caused by this PR)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only adds a documentation entry
- The change is a simple addition to a documentation file with no code or logic changes. The only issue is a minor formatting inconsistency that matches some existing entries but differs from the majority pattern.
- No files require special attention

<sub>Last reviewed commit: e3b00d0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->