### PR TITLE
Correct stale baszel example

### DIFF
--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -27,6 +27,8 @@ At runtime, during the deployment phase, Dokploy automatically adds Traefik labe
 
 **Example:**
 
+For a more complete working example beyond the basic hub, refer to [this pull request](https://github.com/Dokploy/website/pull/145).
+
 Here's a default Docker Compose file:
 
 ```yaml

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -42,7 +42,6 @@ services:
       - 8090
     volumes:
       - beszel_data:/beszel_data
-      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   beszel_data: {}

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -35,7 +35,6 @@ version: "3.8"
 services:
   beszel:
     image: henrygd/beszel:0.18
-    container_name: beszel
     restart: unless-stopped
     #environment:
     #  - APP_URL=http://beszel.lan
@@ -43,6 +42,7 @@ services:
       - 8090
     volumes:
       - beszel_data:/beszel_data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   beszel_data: {}

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -40,7 +40,7 @@ services:
     #environment:
     #  - APP_URL=http://beszel.lan
     ports:
-      - 8090:8090
+      - 8090
     volumes:
       - beszel_data:/beszel_data
 

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -34,13 +34,15 @@ version: "3.8"
 
 services:
   beszel:
-    image: henrygd/beszel:0.10.2
+    image: henrygd/beszel
+    container_name: beszel
     restart: unless-stopped
+    #environment:
+    #  - APP_URL=http://beszel.lan
     ports:
-      - 8090
+      - 8090:8090
     volumes:
       - beszel_data:/beszel_data
-      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   beszel_data: {}

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -59,7 +59,7 @@ version: "3.8"
 
 services:
   beszel:
-    image: henrygd/beszel:0.10.2
+    image: henrygd/beszel:0.18
     restart: unless-stopped
     ports:
       - 8090

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -27,8 +27,6 @@ At runtime, during the deployment phase, Dokploy automatically adds Traefik labe
 
 **Example:**
 
-For a more complete working example beyond the basic hub, refer to [this pull request](https://github.com/Dokploy/website/pull/145).
-
 Here's a default Docker Compose file:
 
 ```yaml

--- a/apps/docs/content/docs/core/docker-compose/domains.mdx
+++ b/apps/docs/content/docs/core/docker-compose/domains.mdx
@@ -34,7 +34,7 @@ version: "3.8"
 
 services:
   beszel:
-    image: henrygd/beszel
+    image: henrygd/beszel:0.18
     container_name: beszel
     restart: unless-stopped
     #environment:


### PR DESCRIPTION
Fixes
```
Image henrygd/beszel:0.10.2 Error Head "https://registry-1.docker.io/v2/henrygd/beszel/manifests/0.10.2": EOF
Error response from daemon: Head "https://registry-1.docker.io/v2/henrygd/beszel/manifests/0.10.2": EOF
Error: ❌ Docker command failed
Error occurred ❌, check the logs for details.
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the first Beszel Docker Compose example in the Domains documentation to reflect a more current configuration: it removes the pinned image version (`0.10.2`), maps the port as `8090`, adds a commented-out `APP_URL` environment variable, and removes the Docker socket volume mount.

However, the second code block immediately below it — which is described as "what the final compose file looks like when deployed" — still contains the old stale values (`henrygd/beszel:0.10.2`, `- 8090` port mapping, and the Docker socket mount). This creates a confusing inconsistency between the two examples in the same documentation section that should be resolved.
EDIT: FIXED

<h3>Confidence Score: 3/5</h3>

- Safe to merge, but contains a documentation inconsistency that should be resolved first.
- The PR correctly updates the first Beszel example, but leaves the second "deployed preview" code block with outdated values (pinned image version 0.10.2, port mapping as `- 8090` instead of `- 8090:8090`, and the Docker socket volume mount). This inconsistency within the same documentation section will confuse readers comparing the two examples and partially defeats the purpose of the fix. The issue is substantive and should be addressed before merge.
- apps/docs/content/docs/core/docker-compose/domains.mdx — the deployed example code block (lines 57–85) needs to be updated to match the corrected input example

<sub>Last reviewed commit: 44ea156</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->