### PR TITLE
Update next.config.mjs

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -6,6 +6,7 @@ const withMDX = createMDX();
 const config = {
 	reactStrictMode: true,
 	output: "standalone",
+	basePath: "/docs",
 	images: {
 		remotePatterns: [
 			{


### PR DESCRIPTION
Adiciona `basePath: "/docs"` no `apps/docs/next.config.mjs` para que o serviço excloud-docs seja servido corretamente em `cloud.exzosverse.com/docs`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `basePath: "/docs"` to `apps/docs/next.config.mjs` to serve the docs app under the `/docs` path prefix on a third-party deployment (`cloud.exzosverse.com/docs`). However, it introduces two critical problems that need to be resolved before merging.

- **URL path doubling**: The docs app already routes content through `app/docs/[[...slug]]`, and `lib/source.ts` sets fumadocs `baseUrl: "/docs"`. Adding `basePath: "/docs"` causes Next.js to prepend `/docs` to all internal routes and `<Link>` hrefs, resulting in every docs page being doubled to `/docs/docs/...` instead of `/docs/...`. This would make the entire docs site navigationally broken.
- **Deployment-specific config in shared repo**: The stated purpose is serving docs at `cloud.exzosverse.com/docs` — a specific third-party deployment. Committing `basePath: "/docs"` to the shared upstream config affects all other deployments (e.g., Dokploy's own docs hosting), and is very likely to break them.
- The correct approach for a reverse-proxy setup is to either configure the proxy to forward traffic without stripping the prefix (since the app already handles `/docs/...` internally), or restructure the app to serve from root and then apply `basePath`.

<h3>Confidence Score: 1/5</h3>

- This PR introduces a breaking change to shared configuration that would break all docs navigation and likely other existing deployments.
- The single-line change causes URL path doubling across the entire docs app due to the conflict between `basePath: "/docs"`, the existing `app/docs/[[...slug]]` route structure, and fumadocs' `baseUrl: "/docs"`. It also modifies a shared upstream config with a deployment-specific value intended only for a third-party host.
- `apps/docs/next.config.mjs` — the only changed file, but the issue cascades to `apps/docs/lib/source.ts` and all route files under `apps/docs/app/`.

<sub>Last reviewed commit: e0e574b</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->