### PR TITLE
docs: Improve preview deployments documentation with reference to variables

### DIFF
--- a/apps/docs/content/docs/core/applications/preview-deployments.mdx
+++ b/apps/docs/content/docs/core/applications/preview-deployments.mdx
@@ -31,6 +31,10 @@ preview-${appName}-${uniqueId}.traefik.me
 
 To make this work, you need to point your wildcard DNS record (*) to your server's IP address.
 
+<Callout type="info">
+**Hint:** If you need to reference the generated domain in the preview deployment's environment variables, you can do so utilising `${{DOKPLOY_DEPLOY_URL}}`. See [variables documentation](/docs/core/variables#service-level-variables) for more information.
+</Callout>
+
 ## How It Works
 
 Once enabled, preview deployments are automatically created whenever a pull request is opened against your target branch (configured in your provider settings).


### PR DESCRIPTION
Added information on referencing generated domain in environment variables for preview deployments.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a small informational callout to the preview deployments documentation, pointing users to the `${{DOKPLOY_DEPLOY_URL}}` service-level variable when they need to reference the generated domain in their environment variables.

The change is accurate — the variable name and syntax (`${{DOKPLOY_DEPLOY_URL}}`) match what is documented in `variables.mdx`, and the anchor link (`/docs/core/variables#service-level-variables`) correctly points to the relevant section.

**Key observations:**
- The variable syntax and name are consistent with the existing variables documentation.
- The anchor link target `#service-level-variables` maps to the `## Service-Level Variables` heading in `variables.mdx`.
- The callout is placed after the wildcard DNS paragraph in the "Custom Domains" subsection, but `DOKPLOY_DEPLOY_URL` is relevant for *all* preview deployments (including the default `traefik.me` domains), not just custom-domain setups. Consider moving it to the top of the `## Configuration` section for better discoverability.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a small, accurate documentation addition with no code changes.
- The only change is adding a documentation callout. The variable name, syntax, and link target have all been verified against the existing codebase and are correct. No functional code is modified.
- No files require special attention.

<sub>Last reviewed commit: c0733d6</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->