### PR TITLE
feat: backups custom file names

### DIFF
--- a/apps/docs/content/docs/core/backups.mdx
+++ b/apps/docs/content/docs/core/backups.mdx
@@ -26,6 +26,33 @@ When a backup is created, Dokploy will:
 - Combine and compress both into a single backup file (.zip)
 - Upload the backup to your specified S3 destination
 
+### Custom File Name Format
+
+You can customize the backup file name using the **File Name Format** option. This allows you to define a pattern using variables that will be replaced when the backup is created.
+
+#### Available Variables
+
+| Variable | Description | Example Output |
+|----------|-------------|----------------|
+| `{timestamp}` | Full ISO timestamp | `2024-01-15T10:30:00` |
+| `{date}` | Date only | `2024-01-15` |
+| `{time}` | Time only (file-safe) | `10-30-00` |
+| `{year}` | Year | `2024` |
+| `{month}` | Month (zero-padded) | `01` |
+| `{day}` | Day (zero-padded) | `15` |
+| `{hour}` | Hour (zero-padded) | `10` |
+| `{minute}` | Minute (zero-padded) | `30` |
+| `{epoch}` | Unix timestamp | `1705315800` |
+| `{uuid}` | Full UUID | `550e8400-e29b-41d4-a716-446655440000` |
+| `{shortUuid}` | 8-character UUID | `550e8400` |
+
+#### Example Formats
+
+- `dokploy-{date}` → `dokploy-2024-01-15`
+- `backup-{timestamp}` → `backup-2024-01-15T10:30:00`
+- `{year}/{month}/dokploy-{day}` → `2024/01/dokploy-15`
+- `dokploy-{shortUuid}` → `dokploy-550e8400`
+
 ## Restoring Backups
 
 To restore a backup:

--- a/apps/docs/content/docs/core/databases/backups.mdx
+++ b/apps/docs/content/docs/core/databases/backups.mdx
@@ -13,7 +13,37 @@ To configure database backups, navigate to the `Backup` tab within your Dokploy 
 - **Database Name**: Enter the name of the database you want to backup.
 - **Schedule Cron**: Define the schedule for your backups using cron syntax.
 - **Prefix**: Choose a prefix under which backups will be stored in your bucket.
+- **File Name Format**: Customize the backup file name using variables (see below).
 - **Enabled**: Toggle whether backups are active. The default setting is enabled.
+
+### Custom File Name Format
+
+You can customize the backup file name using variables that will be replaced when the backup is created.
+
+#### Available Variables
+
+| Variable | Description | Example Output |
+|----------|-------------|----------------|
+| `{timestamp}` | Full ISO timestamp | `2024-01-15T10:30:00` |
+| `{date}` | Date only | `2024-01-15` |
+| `{time}` | Time only (file-safe) | `10-30-00` |
+| `{year}` | Year | `2024` |
+| `{month}` | Month (zero-padded) | `01` |
+| `{day}` | Day (zero-padded) | `15` |
+| `{hour}` | Hour (zero-padded) | `10` |
+| `{minute}` | Minute (zero-padded) | `30` |
+| `{epoch}` | Unix timestamp | `1705315800` |
+| `{uuid}` | Full UUID | `550e8400-e29b-41d4-a716-446655440000` |
+| `{shortUuid}` | 8-character UUID | `550e8400` |
+| `{appName}` | Application name | `my-app` |
+| `{volumeName}` | Volume name | `my-volume` |
+| `{databaseType}` | Database type | `postgres` |
+
+#### Example Formats
+
+- `{appName}-{date}` → `my-app-2024-01-15`
+- `{databaseType}-{timestamp}` → `postgres-2024-01-15T10:30:00`
+- `{appName}-{databaseType}-{shortUuid}` → `my-app-postgres-550e8400`
 
 ### Testing Your Backup Configuration
 


### PR DESCRIPTION
Documentation for the new Custom File Name Format feature for database and volume backups introduced in https://github.com/Dokploy/dokploy/pull/3966.

Updated the backup related docs files to document:
 - The new File Name Format field in backup configuration
 - Available template variables ({timestamp}, {date}, {time}, {appName}, {volumeName}, {databaseType}, {uuid}, etc.)
 - Example format patterns with expected outputs
