### PR TITLE
docs: document automatic DOKPLOY_COMMIT_HASH and DOKPLOY_COMMIT_MESSAGE build variables

### DIFF
--- a/apps/docs/content/docs/core/applications/build-type.mdx
+++ b/apps/docs/content/docs/core/applications/build-type.mdx
@@ -107,6 +107,36 @@ When you enable the Dockerfile build type, two additional fields become availabl
 
 
 
+### Automatic Build Variables
+
+Dokploy automatically injects the following build-time variables into every build, across all builder types:
+
+| Variable                   | Description                                      |
+| :------------------------- | :----------------------------------------------- |
+| `DOKPLOY_COMMIT_HASH`     | The short git commit hash of the deployed commit |
+| `DOKPLOY_COMMIT_MESSAGE`  | The commit message of the deployed commit        |
+
+These variables allow you to track which exact commit is running inside a deployed container, useful for debugging, health endpoints, and observability.
+
+#### Usage with Dockerfile
+
+To make these available at runtime, add the following to your Dockerfile:
+
+```dockerfile
+ARG DOKPLOY_COMMIT_HASH
+ARG DOKPLOY_COMMIT_MESSAGE
+ENV DOKPLOY_COMMIT_HASH=$DOKPLOY_COMMIT_HASH
+ENV DOKPLOY_COMMIT_MESSAGE=$DOKPLOY_COMMIT_MESSAGE
+```
+
+#### Usage with Nixpacks, Heroku, Paketo, and Railpack
+
+For non-Dockerfile builders, these variables are automatically passed as environment variables during the build and are available at runtime without any extra configuration.
+
+<Callout type="info">
+  If the source is not a git repository (e.g., Docker image source), these variables will be set to `unknown`.
+</Callout>
+
 ### Buildpack
 
 Dokploy supports two types of buildpacks:

--- a/apps/docs/content/docs/core/applications/build-type.mdx
+++ b/apps/docs/content/docs/core/applications/build-type.mdx
@@ -113,8 +113,8 @@ Dokploy automatically injects the following build-time variables into every buil
 
 | Variable                   | Description                                       |
 | :------------------------- | :------------------------------------------------ |
-| `DOKPLOY_COMMIT_HASH`     | The short (7-char) git commit hash                |
-| `DOKPLOY_COMMIT_HASH_LONG`| The full git commit hash                          |
+| `DOKPLOY_COMMIT_HASH`     | The full git commit hash                          |
+| `DOKPLOY_COMMIT_SHORT`    | The short (7-char) git commit hash                |
 | `DOKPLOY_COMMIT_MESSAGE`  | The commit message of the deployed commit         |
 
 These variables allow you to track which exact commit is running inside a deployed container, useful for debugging, health endpoints, and observability.
@@ -125,10 +125,10 @@ To make these available at runtime, add the following to your Dockerfile:
 
 ```dockerfile
 ARG DOKPLOY_COMMIT_HASH
-ARG DOKPLOY_COMMIT_HASH_LONG
+ARG DOKPLOY_COMMIT_SHORT
 ARG DOKPLOY_COMMIT_MESSAGE
 ENV DOKPLOY_COMMIT_HASH=$DOKPLOY_COMMIT_HASH
-ENV DOKPLOY_COMMIT_HASH_LONG=$DOKPLOY_COMMIT_HASH_LONG
+ENV DOKPLOY_COMMIT_SHORT=$DOKPLOY_COMMIT_SHORT
 ENV DOKPLOY_COMMIT_MESSAGE=$DOKPLOY_COMMIT_MESSAGE
 ```
 

--- a/apps/docs/content/docs/core/applications/build-type.mdx
+++ b/apps/docs/content/docs/core/applications/build-type.mdx
@@ -111,10 +111,11 @@ When you enable the Dockerfile build type, two additional fields become availabl
 
 Dokploy automatically injects the following build-time variables into every build, across all builder types:
 
-| Variable                   | Description                                      |
-| :------------------------- | :----------------------------------------------- |
-| `DOKPLOY_COMMIT_HASH`     | The short git commit hash of the deployed commit |
-| `DOKPLOY_COMMIT_MESSAGE`  | The commit message of the deployed commit        |
+| Variable                   | Description                                       |
+| :------------------------- | :------------------------------------------------ |
+| `DOKPLOY_COMMIT_HASH`     | The short (7-char) git commit hash                |
+| `DOKPLOY_COMMIT_HASH_LONG`| The full git commit hash                          |
+| `DOKPLOY_COMMIT_MESSAGE`  | The commit message of the deployed commit         |
 
 These variables allow you to track which exact commit is running inside a deployed container, useful for debugging, health endpoints, and observability.
 
@@ -124,8 +125,10 @@ To make these available at runtime, add the following to your Dockerfile:
 
 ```dockerfile
 ARG DOKPLOY_COMMIT_HASH
+ARG DOKPLOY_COMMIT_HASH_LONG
 ARG DOKPLOY_COMMIT_MESSAGE
 ENV DOKPLOY_COMMIT_HASH=$DOKPLOY_COMMIT_HASH
+ENV DOKPLOY_COMMIT_HASH_LONG=$DOKPLOY_COMMIT_HASH_LONG
 ENV DOKPLOY_COMMIT_MESSAGE=$DOKPLOY_COMMIT_MESSAGE
 ```
 


### PR DESCRIPTION
## Summary

Documents the new `DOKPLOY_COMMIT_HASH` and `DOKPLOY_COMMIT_MESSAGE` build variables that are automatically injected by Dokploy during builds.

Related implementation PR: https://github.com/Dokploy/dokploy/pull/4007
Related issue: https://github.com/Dokploy/dokploy/issues/4006

## Changes

Added a new "Automatic Build Variables" section to the Build Type documentation page (`build-type.mdx`) covering:

- Table of the two new variables and their descriptions
- Usage instructions for Dockerfile builds (requires `ARG`/`ENV` lines)
- Note that Nixpacks/Heroku/Paketo/Railpack get them automatically
- Callout about fallback to `unknown` for non-git sources

## Test plan
- [ ] Verify the new section renders correctly on the docs site

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents two new automatic build variables (`DOKPLOY_COMMIT_HASH` and `DOKPLOY_COMMIT_MESSAGE`) that Dokploy injects during builds, with usage instructions for Dockerfile and non-Dockerfile builders.

- Adds a new "Automatic Build Variables" section to `build-type.mdx` with a variable reference table
- Includes Dockerfile usage example showing `ARG`/`ENV` pattern for runtime availability
- Notes that Nixpacks, Heroku, Paketo, and Railpack get these variables automatically
- Adds a callout about fallback to `unknown` for non-git sources
- Clean, well-structured documentation addition with no issues found

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a documentation-only change with no code impact.
- Single file documentation change with correct MDX syntax, proper use of existing Callout component, and accurate content describing the new build variables. No risk to application behavior.
- No files require special attention.

<sub>Last reviewed commit: 87fb0b3</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->