### PR TITLE
docs: add nix-dokploy to goodies

### DIFF
--- a/apps/docs/content/docs/core/goodies.mdx
+++ b/apps/docs/content/docs/core/goodies.mdx
@@ -12,6 +12,6 @@ description: "Dokploy has certain goodies that are external that can be used wit
 6. **Templates Collection** : Docker compose collection for Dokploy [Github](https://github.com/benbristow/dokploy-compose-templates)
 7. **Dokploy Port Updater**: Dokploy Port Updater [Github](https://github.com/clockradios/dokploy-port-updater)
 8. **Dokli TUI**: Dokli TUI [Github](https://github.com/jonykalavera/dokli)
-9. **nix-dokploy**: A NixOS module that runs Dokploy using declarative systemd units [Github](https://github.com/el-kurto/nix-dokploy)
+10. **nix-dokploy**: A NixOS module that runs Dokploy using declarative systemd units [Github](https://github.com/el-kurto/nix-dokploy)
 
 Want to submit your own? [Submit a PR](https://github.com/Dokploy/website/blob/main/README.md)

--- a/apps/docs/content/docs/core/goodies.mdx
+++ b/apps/docs/content/docs/core/goodies.mdx
@@ -12,5 +12,6 @@ description: "Dokploy has certain goodies that are external that can be used wit
 6. **Templates Collection** : Docker compose collection for Dokploy [Github](https://github.com/benbristow/dokploy-compose-templates)
 7. **Dokploy Port Updater**: Dokploy Port Updater [Github](https://github.com/clockradios/dokploy-port-updater)
 8. **Dokli TUI**: Dokli TUI [Github](https://github.com/jonykalavera/dokli)
+9. **nix-dokploy**: A NixOS module that runs Dokploy using declarative systemd units [Github](https://github.com/el-kurto/nix-dokploy)
 
 Want to submit your own? [Submit a PR](https://github.com/Dokploy/website/blob/main/README.md)


### PR DESCRIPTION
Adds [nix-dokploy](https://github.com/el-kurto/nix-dokploy) to the goodies page — a NixOS module that runs Dokploy using declarative systemd units.

As discussed in https://github.com/Dokploy/dokploy/discussions/2632

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new entry for [`nix-dokploy`](https://github.com/el-kurto/nix-dokploy) — a NixOS module that runs Dokploy using declarative systemd units — to the community goodies documentation page. The change is a single-line addition that follows the existing format consistently.

- The new entry is well-formatted and the description is clear and informative.
- There is a pre-existing duplicate list number `5` on line 11 (`Dokploy JS Sdk`), which causes all subsequent items to be numbered one less than their actual position. The new entry is labelled `9` but is logically the 10th item. Fixing the duplicate `5` along with this PR would keep the list accurate.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a simple, isolated documentation addition with no code changes.
- The change is a single line added to a Markdown documentation file. The formatting is consistent with existing entries and the linked repository is valid. The only minor issue (off-by-one list numbering) is a pre-existing problem not introduced by this PR.
- No files require special attention.

<sub>Last reviewed commit: ["docs: add nix-dokplo..."](https://github.com/dokploy/website/commit/e284e32503a3195f815701822b49feab46a3cb48)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->