### PR TITLE
feat(swarm): constrain core services to initial installation node

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -238,9 +238,14 @@ install_dokploy() {
     
     echo "Generated secure database credentials (stored in Docker Secrets)"
 
+    # Add label to current node so we can constrain our services to this node
+    docker node update \
+    --label-add role=dokploy-main \
+    $(hostname)
+
     docker service create \
     --name dokploy-postgres \
-    --constraint 'node.role==manager' \
+    --constraint 'node.labels.role==dokploy-main' \
     --network dokploy-network \
     --env POSTGRES_USER=dokploy \
     --env POSTGRES_DB=dokploy \
@@ -252,7 +257,7 @@ install_dokploy() {
 
     docker service create \
     --name dokploy-redis \
-    --constraint 'node.role==manager' \
+    --constraint 'node.labels.role==dokploy-main' \
     --network dokploy-network \
     --mount type=volume,source=dokploy-redis,target=/data \
     $endpoint_mode \
@@ -280,7 +285,7 @@ install_dokploy() {
       --publish published=3000,target=3000,mode=host \
       --update-parallelism 1 \
       --update-order stop-first \
-      --constraint 'node.role == manager' \
+      --constraint 'node.labels.role==dokploy-main' \
       $endpoint_mode \
       $release_tag_env \
       -e ADVERTISE_ADDR=$advertise_addr \
@@ -306,7 +311,7 @@ install_dokploy() {
     # Optional: Use docker service create instead of docker run
     #   docker service create \
     #     --name dokploy-traefik \
-    #     --constraint 'node.role==manager' \
+    #     --constraint 'node.labels.role==dokploy-main' \
     #     --network dokploy-network \
     #     --mount type=bind,source=/etc/dokploy/traefik/traefik.yml,target=/etc/traefik/traefik.yml \
     #     --mount type=bind,source=/etc/dokploy/traefik/dynamic,target=/etc/dokploy/traefik/dynamic \


### PR DESCRIPTION
Pin the Dokploy management services (web, postgres, and redis) to the node where Dokploy was first deployed. This ensures data persistence and service stability by preventing the orchestrator's core components from migrating across the Swarm cluster.

This is my first PR to an open source project. Please tell me if something is wrong.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the Docker Swarm placement constraints for the three core Dokploy services (postgres, redis, and the web app) from `node.role==manager` (any manager) to `node.labels.role==dokploy-main` (the specific node where Dokploy was installed), and introduces the corresponding `docker node update --label-add` step to stamp that label. The approach is sound and solves a real problem (volume-backed data stores migrating to other managers), but there are two concerns in the implementation:

- **Critical – no error guard on `docker node update`:** If the label command fails for any reason (hostname/node-name mismatch, permission issue, etc.), the script continues, creates all three services with the `node.labels.role==dokploy-main` constraint, and exits successfully — but the services will stay in a perpetual "pending" state because no node carries the label. Adding `|| { echo "…" >&2; exit 1; }` or a simple `if !` check would catch this.
- **Suggestion – use the Docker node ID instead of `$(hostname)`:** `$(docker info --format '{{.Swarm.NodeID}}')` is the canonical, Docker-native way to reference the current node and avoids any potential hostname ↔ Swarm-node-name mismatch.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after adding an error guard around `docker node update`; without it a silent failure leaves all core services permanently unscheduled.
- The conceptual change (label-based placement instead of role-based) is correct and well-motivated. The single blocking concern is the missing error check: a failure in `docker node update` is silently swallowed and the install completes with no warning, but Dokploy is completely non-functional. The unquoted `$(hostname)` and hostname-vs-node-ID issues are minor but worth addressing before this ships to users.
- apps/website/public/install.sh — specifically lines 241-244 (the new `docker node update` block)

<sub>Last reviewed commit: ["feat(swarm): constra..."](https://github.com/dokploy/website/commit/6e00c3bbf02908a8221cd55a0d68a73454829e90)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->