### PR TITLE
Enable configuring the health check from install.

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -288,6 +288,17 @@ install_dokploy() {
       $DOCKER_IMAGE
 
     sleep 4
+    
+    HEALTH_EXTRA_OPTS=""
+    if [ "$HEALTH_CMD" = "none" ]; then
+    HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --no-healthcheck"
+    elif [ -n "$HEALTH_CMD" ]; then
+        HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-cmd '$HEALTH_CMD'"
+    fi
+    [ -n "$HEALTH_INTERVAL" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-interval '$HEALTH_INTERVAL'"
+    [ -n "$HEALTH_TIMEOUT" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-timeout '$HEALTH_TIMEOUT'"
+    [ -n "$HEALTH_RETRIES" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-retries '$HEALTH_RETRIES'"
+    [ -n "$HEALTH_START_PERIOD" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-start-period '$HEALTH_START_PERIOD'"
 
     docker run -d \
         --name dokploy-traefik \
@@ -295,6 +306,7 @@ install_dokploy() {
         -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
         -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
         -v /var/run/docker.sock:/var/run/docker.sock:ro \
+        $HEALTH_EXTRA_OPTS \
         -p 80:80/tcp \
         -p 443:443/tcp \
         -p 443:443/udp \


### PR DESCRIPTION
I am trying to reduce idle CPU usage. Dokpoly is using 2 percent ish on my low powered device. 

I'm not bothered about delth checks

this allows keeping them, turning them off, and configuring the values
```
HEALTH_CMD=none sh install.sh`
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `HEALTH_CMD`, `HEALTH_INTERVAL`, `HEALTH_TIMEOUT`, `HEALTH_RETRIES`, and `HEALTH_START_PERIOD` environment-variable overrides for the Traefik container's health check, and correctly handles `HEALTH_CMD=none` via Docker's `--no-healthcheck` flag. The HEALTH_CMD=none fix from the previous review round is now properly implemented.

Two unresolved concerns carry over: the word-splitting bug when health-check values contain spaces (e.g. `HEALTH_CMD=\"curl -f http://localhost/\"` — single-quotes embedded in an unquoted variable expansion are treated literally, not as shell quoting) and the new finding that combining `HEALTH_CMD=none` with any of the interval/timeout/retries/start-period variables passes both `--no-healthcheck` and a `--health-*` flag to Docker, which Docker rejects outright.

<h3>Confidence Score: 4/5</h3>

Not ready to merge — an existing P1 word-splitting bug is unresolved and a new edge-case conflict can prevent Traefik from starting.

The HEALTH_CMD=none fix is now correct. However, the P1 word-splitting issue flagged in the previous review round remains unaddressed (single-quoted values inside an unquoted $HEALTH_EXTRA_OPTS are not protected from word splitting, so multi-word health-cmd values are mis-parsed). Additionally, a new bug exists where combining HEALTH_CMD=none with any of the interval/timeout/retries/start-period variables produces a docker command Docker refuses to execute.

apps/website/public/install.sh — specifically the HEALTH_EXTRA_OPTS construction and its unquoted expansion in the docker run call.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/website/public/install.sh`, line 292-306 ([link](https://github.com/dokploy/website/blob/024c76255014ffe284ed4ab0abfacb8de91668d9/apps/website/public/install.sh#L292-L306)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Health-check options are only applied to the Traefik container**

   The `docker service create` block for the main `dokploy` service (lines 272–288) does not receive any of the new `HEALTH_*` variables. If the motivation is reducing idle CPU caused by health probes, the `dokploy` service is also a candidate. This may be intentional, but it is worth documenting or extending the feature to be consistent.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix as per AI, plus add sh compatibility..."](https://github.com/dokploy/website/commit/9cd193b0abfc1cf0777f36945ea196af6de52f20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29258056)</sub>

<!-- /greptile_comment -->