### PR TITLE
Options to enable configuring install for lower idle CPU.

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -268,6 +268,17 @@ install_dokploy() {
         # canary, feature/*, etc. → use the tag as-is
         release_tag_env="-e RELEASE_TAG=$VERSION_TAG"
     fi
+
+    HEALTH_EXTRA_OPTS=""
+    if [ "$HEALTH_CMD" = "none" ]; then
+    HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --no-healthcheck"
+    elif [ -n "$HEALTH_CMD" ]; then
+        HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-cmd '$HEALTH_CMD'"
+    fi
+    [ -n "$HEALTH_INTERVAL" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-interval '$HEALTH_INTERVAL'"
+    [ -n "$HEALTH_TIMEOUT" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-timeout '$HEALTH_TIMEOUT'"
+    [ -n "$HEALTH_RETRIES" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-retries '$HEALTH_RETRIES'"
+    [ -n "$HEALTH_START_PERIOD" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-start-period '$HEALTH_START_PERIOD'"
     
     docker service create \
       --name dokploy \
@@ -281,6 +292,7 @@ install_dokploy() {
       --update-parallelism 1 \
       --update-order stop-first \
       --constraint 'node.role == manager' \
+      $HEALTH_EXTRA_OPTS \
       $endpoint_mode \
       $release_tag_env \
       -e ADVERTISE_ADDR=$advertise_addr \
@@ -295,6 +307,7 @@ install_dokploy() {
         -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
         -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
         -v /var/run/docker.sock:/var/run/docker.sock:ro \
+        $HEALTH_EXTRA_OPTS \
         -p 80:80/tcp \
         -p 443:443/tcp \
         -p 443:443/udp \

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -250,13 +250,18 @@ install_dokploy() {
     $endpoint_mode \
     postgres:16
 
+    redis_args=""
+    if [ -n "$REDIS_HZ" ]; then
+        redis_args="redis-server --hz $REDIS_HZ --dynamic-hz yes"
+    fi
+
     docker service create \
     --name dokploy-redis \
     --constraint 'node.role==manager' \
     --network dokploy-network \
     --mount type=volume,source=dokploy-redis,target=/data \
     $endpoint_mode \
-    redis:7
+    redis:7 $redis_args
 
     # Installation
     # Set RELEASE_TAG environment variable for canary/feature versions

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -250,7 +250,7 @@ install_dokploy() {
     $endpoint_mode \
     postgres:16
 
-    redis_args=""
+    redis_args="redis-server"
     if [ -n "$REDIS_HZ" ]; then
         redis_args="redis-server --hz $REDIS_HZ --dynamic-hz yes"
     fi

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -273,12 +273,12 @@ install_dokploy() {
     if [ "$HEALTH_CMD" = "none" ]; then
         HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --no-healthcheck"
     elif [ -n "$HEALTH_CMD" ]; then
-        HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-cmd '$HEALTH_CMD'"
+        HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-cmd $HEALTH_CMD"
     fi
-    [ -n "$HEALTH_INTERVAL" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-interval '$HEALTH_INTERVAL'"
-    [ -n "$HEALTH_TIMEOUT" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-timeout '$HEALTH_TIMEOUT'"
-    [ -n "$HEALTH_RETRIES" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-retries '$HEALTH_RETRIES'"
-    [ -n "$HEALTH_START_PERIOD" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-start-period '$HEALTH_START_PERIOD'"
+    [ -n "$HEALTH_INTERVAL" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-interval $HEALTH_INTERVAL"
+    [ -n "$HEALTH_TIMEOUT" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-timeout $HEALTH_TIMEOUT"
+    [ -n "$HEALTH_RETRIES" ]  && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-retries $HEALTH_RETRIES"
+    [ -n "$HEALTH_START_PERIOD" ] && HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-start-period $HEALTH_START_PERIOD"
     
     docker service create \
       --name dokploy \

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -271,7 +271,7 @@ install_dokploy() {
 
     HEALTH_EXTRA_OPTS=""
     if [ "$HEALTH_CMD" = "none" ]; then
-    HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --no-healthcheck"
+        HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --no-healthcheck"
     elif [ -n "$HEALTH_CMD" ]; then
         HEALTH_EXTRA_OPTS="$HEALTH_EXTRA_OPTS --health-cmd '$HEALTH_CMD'"
     fi

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -307,7 +307,6 @@ install_dokploy() {
         -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
         -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
         -v /var/run/docker.sock:/var/run/docker.sock:ro \
-        $HEALTH_EXTRA_OPTS \
         -p 80:80/tcp \
         -p 443:443/tcp \
         -p 443:443/udp \


### PR DESCRIPTION
- Allow redis polling to be reduced via hz option
- Allow configuring dokploy server health check options - turning them off.

I am trying to reduce idle CPU usage. Dokpoly is using 2 percent ish on my low powered device. 
I would like an option to remove redis, and postgres,, but postgres ..

I'm not bothered about delth checks

this allows keeping them, turning them off, and configuring the values
```
HEALTH_CMD=none sh install.sh`
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two install-time options to reduce idle CPU: a `REDIS_HZ` env var to lower the Redis polling frequency, and a family of `HEALTH_*` env vars (`HEALTH_CMD=none` being the primary advertised use case) to configure or disable Docker health checks on the dokploy service.

- `HEALTH_CMD=none` combined with any `HEALTH_INTERVAL`/`HEALTH_TIMEOUT`/`HEALTH_RETRIES`/`HEALTH_START_PERIOD` variable will produce `--no-healthcheck --health-interval …`, which Docker rejects; the timing checks need to be gated on `HEALTH_CMD != "none"`.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the --no-healthcheck / health-timing conflict is resolved.

One P1 defect: Docker rejects --no-healthcheck alongside --health-interval/--health-timeout/etc., which can occur with a plausible user configuration. The P2 (unconditional redis-server command) is low-risk given Redis 7's default CMD, and the fix is straightforward.

apps/website/public/install.sh — specifically the HEALTH_EXTRA_OPTS construction block (lines 277–286) and the redis_args initialization (line 253).

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/website/public/install.sh`, line 310 ([link](https://github.com/dokploy/website/blob/70cf9485491cc4ec85c31af896620334de4f4c30/apps/website/public/install.sh#L310)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Health options shared between dokploy and Traefik containers**

   `$HEALTH_EXTRA_OPTS` is applied to the Traefik `docker run` call here in addition to the `docker service create` for dokploy. If the intent is only to reduce CPU for the dokploy container, Traefik's health checks are being altered as a side-effect. If both are intentional, consider documenting this behaviour so future readers know it's by design.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Add no args redis command."](https://github.com/dokploy/website/commit/e3890e218b48476de7050296d8049934bfec11ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29260653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->