### PR TITLE
docs: add Cloudflare Mesh guide

### DIFF
--- a/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
@@ -1,0 +1,72 @@
+---
+title: Cloudflare Mesh
+description: Learn how to use Cloudflare Mesh for private Dokploy remote-server SSH and IP routing.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Cloudflare Mesh creates a private network between servers that run Cloudflare One Client/WARP. For Dokploy, it is most useful when the Dokploy admin server needs a normal private IP path to remote servers over SSH.
+
+Keep Cloudflare Tunnel and Access for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites. Use Mesh for private server-to-server paths where Dokploy expects a regular IP address and port.
+
+## What is Cloudflare Mesh?
+
+Cloudflare Mesh connects enrolled devices through Cloudflare Zero Trust and assigns each device a private Mesh IP address, often in the `100.96.0.0/12` range. Dokploy can use that private IP as the host for a remote server while keeping public SSH closed after verification.
+
+Do not use Mesh as the public website publishing layer. Public websites and admin panels should continue to use Cloudflare Tunnel routes so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
+
+## When to use Cloudflare Mesh
+
+- Dokploy admin server to remote Dokploy nodes
+- Deployments that need SSH access to worker or application servers
+- Private service calls between Dokploy-managed machines
+- Closing public SSH while preserving Dokploy remote-server management
+
+## Prerequisites
+
+Before using Cloudflare Mesh with Dokploy, ensure you have:
+
+- Cloudflare Zero Trust with Mesh enabled
+- Cloudflare One Client/WARP installed on the Dokploy admin server and each remote server
+- A Mesh node token created in **Zero Trust** → **Networks** → **Mesh**
+- SSH access or console access kept available while testing
+
+<Callout type="warn">
+  Verify your WARP device profile and split tunnel settings before running `warp-cli connect`. Broad WARP routing can interrupt server connectivity. Keep public SSH or another recovery path available until Mesh and Dokploy remote connectivity are verified.
+</Callout>
+
+## Cloudflare Mesh Setup
+
+This guide assumes you already have Dokploy installed and at least one remote server that Dokploy manages over SSH.
+
+1. In Cloudflare Zero Trust, go to **Networks** → **Mesh**.
+2. Enable Mesh connections and unique IP addresses for devices.
+3. Create a node token. Store it securely and do not commit it to your repository.
+4. Install Cloudflare One Client/WARP on the Dokploy admin server and each remote server.
+5. Enroll each server with the node token, then connect WARP.
+6. Confirm that each server receives a private Mesh IP.
+
+## Update Dokploy remote servers
+
+After Mesh is connected, update each Dokploy remote server to use the remote server's Mesh IP:
+
+```txt
+Host: <REMOTE_SERVER_MESH_IP>
+Port: 22
+```
+
+From the Dokploy admin server, verify SSH over Mesh before changing firewall rules:
+
+```bash
+ssh root@<REMOTE_SERVER_MESH_IP> hostname
+```
+
+Then verify in Dokploy that the remote server connects successfully on port `22`.
+
+<Callout type="info">
+  Mesh gives Dokploy a normal private IP endpoint, which is cleaner for Dokploy remote servers than Access SSH patterns that require a client-side `cloudflared access ssh` ProxyCommand.
+</Callout>
+
+<Callout type="warn">
+  Only close public SSH in your host or cloud firewall after Mesh SSH and Dokploy remote-server connectivity both work. Keep `sshd` running so the server remains reachable over the Mesh path.
+</Callout>

--- a/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
@@ -5,68 +5,114 @@ description: Learn how to use Cloudflare Mesh for private Dokploy remote-server 
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Cloudflare Mesh creates a private network between servers that run Cloudflare One Client/WARP. For Dokploy, it is most useful when the Dokploy admin server needs a normal private IP path to remote servers over SSH.
+Cloudflare Mesh creates a private network between servers that run Cloudflare One Client/WARP. This is useful for Dokploy remote servers because Dokploy expects a normal SSH endpoint: an IP address and port `22`.
 
-Keep Cloudflare Tunnel and Access for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites. Use Mesh for private server-to-server paths where Dokploy expects a regular IP address and port.
+Use Cloudflare Tunnel and Access for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites. Use Cloudflare Mesh for private server-to-server paths, such as the Dokploy admin server connecting to remote Dokploy nodes over SSH.
 
 ## What is Cloudflare Mesh?
 
-Cloudflare Mesh connects enrolled devices through Cloudflare Zero Trust and assigns each device a private Mesh IP address, often in the `100.96.0.0/12` range. Dokploy can use that private IP as the host for a remote server while keeping public SSH closed after verification.
+Cloudflare Mesh connects enrolled devices through Cloudflare Zero Trust and gives each device a private Mesh IP address, often in the `100.96.0.0/12` range. After the Dokploy admin server and remote servers are enrolled, Dokploy can use a remote server's Mesh IP as its SSH host.
 
-Do not use Mesh as the public website publishing layer. Public websites and admin panels should continue to use Cloudflare Tunnel routes so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
+### Benefits
 
-## When to use Cloudflare Mesh
+- **Private Remote SSH**: Connect Dokploy to remote servers without relying on public IPs
+- **Normal IP Endpoint**: Use a private Mesh IP and port `22`, which matches how Dokploy remote servers connect
+- **Reduced Exposure**: Close public SSH after the Mesh path is verified
+- **Server-to-Server Routing**: Support private calls between Dokploy-managed machines
+- **Cloudflare Zero Trust**: Manage Mesh enrollment and device policy from Cloudflare
 
-- Dokploy admin server to remote Dokploy nodes
-- Deployments that need SSH access to worker or application servers
-- Private service calls between Dokploy-managed machines
-- Closing public SSH while preserving Dokploy remote-server management
+<Callout type="info">
+  Mesh is not a replacement for Cloudflare Tunnel routes. Public websites and admin panels should continue to use Tunnel and Access so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
+</Callout>
 
 ## Prerequisites
 
-Before using Cloudflare Mesh with Dokploy, ensure you have:
+Before setting up Cloudflare Mesh with Dokploy, ensure you have:
 
-- Cloudflare Zero Trust with Mesh enabled
-- Cloudflare One Client/WARP installed on the Dokploy admin server and each remote server
-- A Mesh node token created in **Zero Trust** → **Networks** → **Mesh**
-- SSH access or console access kept available while testing
+- Cloudflare Zero Trust access with Mesh available
+- Dokploy installed and running
+- At least one remote server managed by Dokploy over SSH
+- SSH or console access to the Dokploy admin server and each remote server
+- Cloudflare One Client/WARP installed on every server that should join Mesh
 
 <Callout type="warn">
-  Verify your WARP device profile and split tunnel settings before running `warp-cli connect`. Broad WARP routing can interrupt server connectivity. Keep public SSH or another recovery path available until Mesh and Dokploy remote connectivity are verified.
+  Verify your WARP device profile and split tunnel settings before running `warp-cli connect`. Broad WARP routing can interrupt server connectivity. Keep public SSH or another recovery path available until Mesh SSH and Dokploy remote connectivity are verified.
 </Callout>
 
 ## Cloudflare Mesh Setup
 
-This guide assumes you already have Dokploy installed and at least one remote server that Dokploy manages over SSH.
+This guide walks through the high-level Mesh setup for Dokploy remote servers. Repeat the server-side steps for the Dokploy admin server and each remote server that Dokploy needs to manage.
 
-1. In Cloudflare Zero Trust, go to **Networks** → **Mesh**.
-2. Enable Mesh connections and unique IP addresses for devices.
-3. Create a node token. Store it securely and do not commit it to your repository.
-4. Install Cloudflare One Client/WARP on the Dokploy admin server and each remote server.
-5. Enroll each server with the node token, then connect WARP.
-6. Confirm that each server receives a private Mesh IP.
+### Step 1: Enable Mesh in Cloudflare Zero Trust
 
-## Update Dokploy remote servers
+1. Log in to your [Cloudflare Dashboard](https://dash.cloudflare.com/)
+2. Open **Zero Trust**
+3. Go to **Networks** → **Mesh**
+4. Enable Mesh connections
+5. Enable unique IP addresses for devices
 
-After Mesh is connected, update each Dokploy remote server to use the remote server's Mesh IP:
+### Step 2: Create a Mesh node token
+
+In the Mesh settings, create a node token for enrolling servers.
+
+<Callout type="info">
+  Keep the Mesh node token secure. It enrolls devices into your private Mesh network and should not be committed to your repository or shared in logs.
+</Callout>
+
+### Step 3: Install Cloudflare One Client/WARP on each server
+
+Install Cloudflare One Client/WARP on:
+
+- The Dokploy admin server
+- Each remote server that Dokploy manages over SSH
+
+Use Cloudflare's current installation instructions for your server operating system, then confirm `warp-cli` is available.
+
+### Step 4: Enroll and connect each server
+
+On each server, enroll the device with your Mesh node token:
+
+```bash
+sudo warp-cli --accept-tos connector new <MESH_NODE_TOKEN>
+```
+
+Then connect WARP:
+
+```bash
+sudo warp-cli --accept-tos connect
+```
+
+After connecting, confirm the device appears in Cloudflare Zero Trust and has a Mesh IP address.
+
+### Step 5: Verify Mesh connectivity
+
+From the Dokploy admin server, test SSH to the remote server's Mesh IP:
+
+```bash
+ssh root@<REMOTE_SERVER_MESH_IP> hostname
+```
+
+If this fails, keep public SSH or console access available while you check WARP status, Mesh enrollment, device policy, and host firewall rules.
+
+## Update Dokploy Remote Servers
+
+After Mesh SSH works, update the remote server in Dokploy to use the remote server's Mesh IP:
 
 ```txt
 Host: <REMOTE_SERVER_MESH_IP>
 Port: 22
 ```
 
-From the Dokploy admin server, verify SSH over Mesh before changing firewall rules:
-
-```bash
-ssh root@<REMOTE_SERVER_MESH_IP> hostname
-```
-
-Then verify in Dokploy that the remote server connects successfully on port `22`.
+Then validate the remote server connection from the Dokploy UI. Dokploy should be able to reach the remote server on the Mesh IP at port `22`.
 
 <Callout type="info">
   Mesh gives Dokploy a normal private IP endpoint, which is cleaner for Dokploy remote servers than Access SSH patterns that require a client-side `cloudflared access ssh` ProxyCommand.
 </Callout>
 
+## Securing Your Server
+
+Once Mesh SSH and Dokploy remote-server connectivity both work, you can close public SSH in your host or cloud firewall. Keep `sshd` running so the server remains reachable through the Mesh IP.
+
 <Callout type="warn">
-  Only close public SSH in your host or cloud firewall after Mesh SSH and Dokploy remote-server connectivity both work. Keep `sshd` running so the server remains reachable over the Mesh path.
+  Do not close public SSH until you have verified both direct Mesh SSH from the Dokploy admin server and Dokploy's remote-server connection. Keep a console or other recovery path available for future network changes.
 </Callout>

--- a/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-mesh.mdx
@@ -22,7 +22,7 @@ Cloudflare Mesh connects enrolled devices through Cloudflare Zero Trust and give
 - **Cloudflare Zero Trust**: Manage Mesh enrollment and device policy from Cloudflare
 
 <Callout type="info">
-  Mesh is not a replacement for Cloudflare Tunnel routes. Public websites and admin panels should continue to use Tunnel and Access so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
+  Mesh is not a replacement for [Cloudflare Tunnel routes](/docs/core/guides/cloudflare-tunnels). Public websites and admin panels should continue to use Tunnel and Access so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
 </Callout>
 
 ## Prerequisites
@@ -66,9 +66,25 @@ Install Cloudflare One Client/WARP on:
 - The Dokploy admin server
 - Each remote server that Dokploy manages over SSH
 
-Use Cloudflare's current installation instructions for your server operating system, then confirm `warp-cli` is available.
+Use Cloudflare's [headless Linux Cloudflare One Client tutorial](https://developers.cloudflare.com/cloudflare-one/tutorials/deploy-client-headless-linux/) or the current installation instructions for your server operating system, then confirm `warp-cli` is available.
 
-### Step 4: Enroll and connect each server
+### Step 4: Configure and verify the WARP device profile
+
+Before connecting WARP on a server, create or verify a dedicated Mesh-node device profile in Cloudflare Zero Trust:
+
+- Use **Traffic and DNS** mode
+- Use [Split Tunnels](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) **Include** mode
+- Include `100.96.0.0/12` for Cloudflare Mesh device IPs
+
+On each server, check the applied WARP settings before connecting:
+
+```bash
+warp-cli --accept-tos settings
+```
+
+Do not run `warp-cli connect` if the expected Mesh profile, Include mode, and `100.96.0.0/12` route are not shown, or if the profile would broadly reroute server traffic.
+
+### Step 5: Enroll and connect each server
 
 On each server, enroll the device with your Mesh node token:
 
@@ -84,7 +100,7 @@ sudo warp-cli --accept-tos connect
 
 After connecting, confirm the device appears in Cloudflare Zero Trust and has a Mesh IP address.
 
-### Step 5: Verify Mesh connectivity
+### Step 6: Verify Mesh connectivity
 
 From the Dokploy admin server, test SSH to the remote server's Mesh IP:
 

--- a/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
@@ -217,9 +217,3 @@ This ensures Dokploy includes your domain as a trusted origin automatically.
 <Callout type="warn">
   If you access Dokploy through multiple origins (public domain, internal IP, Tailscale), make sure all of them are listed in `BETTER_AUTH_TRUSTED_ORIGINS`.
 </Callout>
-
-## Cloudflare Mesh
-
-Cloudflare Tunnel and Access are best for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites.
-
-For private Dokploy server-to-server connectivity, such as remote-server SSH over a private IP, see the [Cloudflare Mesh guide](/docs/core/guides/cloudflare-mesh).

--- a/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
@@ -217,3 +217,63 @@ This ensures Dokploy includes your domain as a trusted origin automatically.
 <Callout type="warn">
   If you access Dokploy through multiple origins (public domain, internal IP, Tailscale), make sure all of them are listed in `BETTER_AUTH_TRUSTED_ORIGINS`.
 </Callout>
+
+## Cloudflare Mesh
+
+Cloudflare Mesh is useful when Dokploy needs private server-to-server connectivity. Keep Cloudflare Tunnel and Access for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites. Use Mesh for private paths where Dokploy expects a normal IP address and port, such as connecting the Dokploy admin server to remote Dokploy nodes over SSH.
+
+Do not use Mesh as the public website publishing layer. Public websites and admin panels should continue to use Tunnel routes so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
+
+### When to use Mesh
+
+- Dokploy admin server to remote Dokploy nodes
+- Deployments that need SSH access to worker or application servers
+- Private service calls between Dokploy-managed machines
+- Closing public SSH while preserving Dokploy remote-server management
+
+### Prerequisites
+
+Before using Cloudflare Mesh with Dokploy, ensure you have:
+
+- Cloudflare Zero Trust with Mesh enabled
+- Cloudflare One Client/WARP installed on the Dokploy admin server and each remote server
+- A Mesh node token created in **Zero Trust** → **Networks** → **Mesh**
+- SSH access or console access kept available while testing
+
+<Callout type="warn">
+  Verify your device profile and split tunnel settings before running `warp-cli connect`. Broad WARP routing can interrupt server connectivity. Keep public SSH or another recovery path open until Mesh and Dokploy remote connectivity are verified.
+</Callout>
+
+### Setup overview
+
+1. In Cloudflare Zero Trust, go to **Networks** → **Mesh**.
+2. Enable Mesh connections and unique IP addresses for devices.
+3. Create a node token. Store it securely and do not commit it to your repository.
+4. Install Cloudflare One Client/WARP on the Dokploy admin server and each remote server.
+5. Enroll each server with the node token, then connect WARP.
+6. Confirm each server receives a Mesh IP, often in the `100.96.0.0/12` range.
+
+### Update Dokploy remote servers
+
+After Mesh is connected, update each Dokploy remote server to use the remote server's Mesh IP:
+
+```txt
+Host: <REMOTE_SERVER_MESH_IP>
+Port: 22
+```
+
+From the Dokploy admin server, verify SSH over Mesh before changing firewall rules:
+
+```bash
+ssh root@<REMOTE_SERVER_MESH_IP> hostname
+```
+
+Then verify in Dokploy that the remote server connects successfully on port `22`.
+
+<Callout type="info">
+  Mesh gives Dokploy a normal private IP endpoint, which is cleaner for Dokploy remote servers than Access SSH patterns that require a client-side `cloudflared access ssh` ProxyCommand.
+</Callout>
+
+<Callout type="warn">
+  Only close public SSH in your host or cloud firewall after Mesh SSH and Dokploy remote-server connectivity both work. Keep `sshd` running so the server remains reachable over the Mesh path.
+</Callout>

--- a/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
+++ b/apps/docs/content/docs/core/guides/cloudflare-tunnels.mdx
@@ -220,60 +220,6 @@ This ensures Dokploy includes your domain as a trusted origin automatically.
 
 ## Cloudflare Mesh
 
-Cloudflare Mesh is useful when Dokploy needs private server-to-server connectivity. Keep Cloudflare Tunnel and Access for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites. Use Mesh for private paths where Dokploy expects a normal IP address and port, such as connecting the Dokploy admin server to remote Dokploy nodes over SSH.
+Cloudflare Tunnel and Access are best for public or human-facing entrypoints, such as the Dokploy dashboard, browser-protected tools, human SSH through Access, and public websites.
 
-Do not use Mesh as the public website publishing layer. Public websites and admin panels should continue to use Tunnel routes so Cloudflare can terminate HTTP(S), apply Access and WAF controls, and keep origin ports closed.
-
-### When to use Mesh
-
-- Dokploy admin server to remote Dokploy nodes
-- Deployments that need SSH access to worker or application servers
-- Private service calls between Dokploy-managed machines
-- Closing public SSH while preserving Dokploy remote-server management
-
-### Prerequisites
-
-Before using Cloudflare Mesh with Dokploy, ensure you have:
-
-- Cloudflare Zero Trust with Mesh enabled
-- Cloudflare One Client/WARP installed on the Dokploy admin server and each remote server
-- A Mesh node token created in **Zero Trust** → **Networks** → **Mesh**
-- SSH access or console access kept available while testing
-
-<Callout type="warn">
-  Verify your device profile and split tunnel settings before running `warp-cli connect`. Broad WARP routing can interrupt server connectivity. Keep public SSH or another recovery path open until Mesh and Dokploy remote connectivity are verified.
-</Callout>
-
-### Setup overview
-
-1. In Cloudflare Zero Trust, go to **Networks** → **Mesh**.
-2. Enable Mesh connections and unique IP addresses for devices.
-3. Create a node token. Store it securely and do not commit it to your repository.
-4. Install Cloudflare One Client/WARP on the Dokploy admin server and each remote server.
-5. Enroll each server with the node token, then connect WARP.
-6. Confirm each server receives a Mesh IP, often in the `100.96.0.0/12` range.
-
-### Update Dokploy remote servers
-
-After Mesh is connected, update each Dokploy remote server to use the remote server's Mesh IP:
-
-```txt
-Host: <REMOTE_SERVER_MESH_IP>
-Port: 22
-```
-
-From the Dokploy admin server, verify SSH over Mesh before changing firewall rules:
-
-```bash
-ssh root@<REMOTE_SERVER_MESH_IP> hostname
-```
-
-Then verify in Dokploy that the remote server connects successfully on port `22`.
-
-<Callout type="info">
-  Mesh gives Dokploy a normal private IP endpoint, which is cleaner for Dokploy remote servers than Access SSH patterns that require a client-side `cloudflared access ssh` ProxyCommand.
-</Callout>
-
-<Callout type="warn">
-  Only close public SSH in your host or cloud firewall after Mesh SSH and Dokploy remote-server connectivity both work. Keep `sshd` running so the server remains reachable over the Mesh path.
-</Callout>
+For private Dokploy server-to-server connectivity, such as remote-server SSH over a private IP, see the [Cloudflare Mesh guide](/docs/core/guides/cloudflare-mesh).

--- a/apps/docs/content/docs/core/meta.json
+++ b/apps/docs/content/docs/core/meta.json
@@ -62,6 +62,7 @@
 		"enterprise/audit-logs",
 		"---Guides---",
 		"guides/cloudflare-tunnels",
+		"guides/cloudflare-mesh",
 		"guides/tailscale",
 		"guides/ec2-instructions"
 	]


### PR DESCRIPTION
## Summary
- add a standalone Cloudflare Mesh guide for Dokploy remote-server SSH over private Mesh IPs
- link Cloudflare One Client install and Split Tunnels docs so setup steps are easier to follow
- include WARP device profile checks before `warp-cli connect` to avoid routing server traffic too broadly
- remove the extra Mesh pointer from the Cloudflare Tunnels page because Mesh is already listed in the sidebar

## Real-world validation
I followed this setup on 3 VPSs: 1 Dokploy admin VPS and 2 remote servers managed over SSH. With Mesh in place, I was able to close the public SSH port on all of them while the Dokploy admin server could still connect to and manage the remote servers over their Mesh IPs.

## Verification
- `pnpm --filter=docs run types:check`
- `pnpm docs:build`
- `git diff --check`
