### PR TITLE
docs: clarify that custom compose command replaces the default instead of appending

### DIFF
--- a/apps/docs/content/docs/core/docker-compose/index.mdx
+++ b/apps/docs/content/docs/core/docker-compose/index.mdx
@@ -65,7 +65,7 @@ We provide a webhook so that you can trigger your own deployments by pushing to 
 
 This section provides advanced configuration options for experienced users. It includes tools for custom commands within the container and volumes.
 
-- **Command**: Dokploy has a defined command to run the Docker Compose file, ensuring complete control through the UI. However, you can append flags or options to the command.
+- **Command**: Dokploy has a defined command to run the Docker Compose file, ensuring complete control through the UI. However, you can override it with a custom command. Note that the custom command fully replaces the default one (it does not append to it), so if you only need extra flags like `--force-recreate`, you must write the full command based on the default shown in the UI. The command always starts with `docker`, so a custom command like `compose -p <app-name> -f <compose-path> up -d --build --remove-orphans --force-recreate` will run as `docker compose ...`.
   
   <Callout type="info" title="Using Private Registries with Docker Stack">
   If you're deploying with **Docker Stack** (Docker Swarm mode) using **replicas** and a **private registry**, you need to add the `--with-registry-auth` flag to ensure that registry credentials are properly distributed to all nodes in your swarm.

--- a/apps/docs/content/docs/core/features.mdx
+++ b/apps/docs/content/docs/core/features.mdx
@@ -72,7 +72,7 @@ Enhance your Docker Compose experience with these advanced functionalities:
   2. Cancel queued deployments in case you have a lot of deployments in the queue, the most common is when you push alot of times in your repository, you can cancel the incoming queues, not the deployments that are already running.
 
 **Advanced Settings**:
-  1. Append command, by default we use a internal command to build the docker compose however, you can append a command to the existing one.
+  1. Custom command, by default we use an internal command to build the docker compose, however you can override it with your own command. Note that the custom command fully replaces the default one (the default command is shown in the UI as a reference, and the command always starts with `docker`).
   2. Manage volumes and mounts.
 
 ## Database Deployment


### PR DESCRIPTION
## Summary

The docs claimed the compose `Command` field **appends** to the default command, but `createCommand` in [dokploy](https://github.com/Dokploy/dokploy/blob/canary/packages/server/src/utils/builders/compose.ts#L82) fully **replaces** it with the custom command (executed as `docker <command>`). The UI already describes it correctly as an override.

This updates both pages that mentioned the append behavior:

- `core/features.mdx`: now describes the field as a custom command that fully replaces the default one.
- `core/docker-compose/index.mdx`: now explains the replacement behavior, that the command always starts with `docker`, and shows an example of a full custom command with `--force-recreate`.

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)