### PR TITLE
feat: display local IP alongside public IP in install success message

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -361,11 +361,18 @@ install_dokploy() {
     }
 
     public_ip="${ADVERTISE_ADDR:-$(get_ip)}"
+    private_ip=$(get_private_ip)
     formatted_addr=$(format_ip_for_url "$public_ip")
     echo ""
     printf "${GREEN}Congratulations, Dokploy is installed!${NC}\n"
     printf "${BLUE}Wait 15 seconds for the server to start${NC}\n"
-    printf "${YELLOW}Please go to http://${formatted_addr}:3000${NC}\n\n"
+    printf "${YELLOW}Please go to http://${formatted_addr}:3000${NC}\n"
+    # Home servers and local VMs are often not reachable on their public IP
+    # (no port forwarding), so also print the private IP when there is one.
+    if [ -n "$private_ip" ] && [ "$private_ip" != "$public_ip" ]; then
+        printf "${YELLOW}If you are on the same local network, use http://${private_ip}:3000${NC}\n"
+    fi
+    printf "\n"
 }
 
 update_dokploy() {


### PR DESCRIPTION
## Summary

The install script's final message only printed the public IP URL. Users installing Dokploy on local VMs or home hardware often can't reach that address because no port forwarding is configured, so a successful install looks broken.

This reuses the existing `get_private_ip()` helper (already used for the swarm advertise address) to also print the local URL:

```
Congratulations, Dokploy is installed!
Wait 15 seconds for the server to start
Please go to http://<public-ip>:3000
If you are on the same local network, use http://<private-ip>:3000
```

The extra line is only shown when a private (RFC1918) IP is detected **and** it differs from the address already displayed — so VPS-only servers and users who passed `ADVERTISE_ADDR` with their local IP see no duplicate line.

## Testing

Verified inside an Alpine container (busybox `ash`) by executing the exact functions and final-message block extracted from the script:

- Default flow → prints public IP **and** local IP (`172.17.0.2`) ✅
- `ADVERTISE_ADDR` set to the private IP → single line, no duplicate ✅
- `ADVERTISE_ADDR` set to a distinct address → both lines ✅
- `sh -n` syntax check passes ✅

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)