### PR TITLE
docs: add Mattermost as a notification provider

### DIFF
--- a/apps/docs/content/docs/core/(Notifications)/mattermost.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/mattermost.mdx
@@ -1,0 +1,28 @@
+---
+title: Mattermost
+description: 'Configure mattermost notifications for your applications.'
+---
+
+
+Mattermost notifications are a great way to stay up to date with important events in your Dokploy panel. You can choose to receive notifications for specific events or all events.
+
+## Mattermost Notifications
+
+To start receiving mattermost notifications, you need to fill the form with the following details:
+
+- **Name**: Enter any name you want.
+- **Webhook URL**: Enter the webhook URL. eg. `https://your-mattermost.com/hooks/xxx-generatedkey-xxx`
+- **Channel**: Enter the channel name that you want to send the notifications to.
+- **Username**: Enter the username that you want to send the notifications by.
+
+To Setup the mattermost notifications, follow these steps:
+
+
+1. Go to `https://your-mattermost.com/organization_name/integrations/incoming_webhooks` and click on `Add Incoming Webhook`.
+2. Enter title, description and select the channel that you want to send the notifications to.
+3. Click on `Save`.
+4. Copy the `Webhook URL`.
+5. Go to Dokploy `Notifications` and select `Mattermost` as the notification provider.
+6. Use the `Webhook URL` you copied in the previous step.
+7. In Channel section, select the channel that you want to send the notifications to.
+8. Click on `Create` to save the notification.

--- a/apps/docs/content/docs/core/(Notifications)/meta.json
+++ b/apps/docs/content/docs/core/(Notifications)/meta.json
@@ -3,10 +3,10 @@
 	"pages": [
 		"overview",
 		"slack",
+		"mattermost",
 		"telegram",
 		"discord",
 		"lark",
-		"teams",
 		"email",
 		"resend",
 		"gotify",

--- a/apps/docs/content/docs/core/(Notifications)/meta.json
+++ b/apps/docs/content/docs/core/(Notifications)/meta.json
@@ -7,6 +7,7 @@
 		"telegram",
 		"discord",
 		"lark",
+		"teams",
 		"email",
 		"resend",
 		"gotify",

--- a/apps/docs/content/docs/core/(Notifications)/overview.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/overview.mdx
@@ -23,10 +23,10 @@ You can select which actions trigger notifications:
 Dokploy supports the following notification providers:
 
 1. **Slack**: Slack is a platform for team communication and collaboration.
-2. **Telegram**: Telegram is a messaging platform that allows users to send and receive messages.
-3. **Discord**: Discord is generally used for communication between users in a chat or voice channel.
-4. **Lark**: Lark is a collaboration platform that provides messaging and team communication features.
-5. **Microsoft Teams**: Microsoft Teams is a collaboration platform that supports incoming webhooks for channel notifications.
+2. **Mattermost**: Mattermost is an open source platform for team communication and collaboration.
+3. **Telegram**: Telegram is a messaging platform that allows users to send and receive messages.
+4. **Discord**: Discord is generally used for communication between users in a chat or voice channel.
+5. **Lark**: Lark is a collaboration platform that provides messaging and team communication features.
 6. **Email**: Email is a popular method for sending messages to a group of recipients.
 7. **Resend**: Resend is a modern email API for developers to send transactional emails.
 8. **Gotify**: Gotify is a self-hosted push notification service.

--- a/apps/docs/content/docs/core/(Notifications)/overview.mdx
+++ b/apps/docs/content/docs/core/(Notifications)/overview.mdx
@@ -27,10 +27,11 @@ Dokploy supports the following notification providers:
 3. **Telegram**: Telegram is a messaging platform that allows users to send and receive messages.
 4. **Discord**: Discord is generally used for communication between users in a chat or voice channel.
 5. **Lark**: Lark is a collaboration platform that provides messaging and team communication features.
-6. **Email**: Email is a popular method for sending messages to a group of recipients.
-7. **Resend**: Resend is a modern email API for developers to send transactional emails.
-8. **Gotify**: Gotify is a self-hosted push notification service.
-9. **Ntfy**: Ntfy is a simple HTTP-based pub-sub notification service.
-10. **Pushover**: Pushover is a service for sending real-time notifications to Android, iOS, and desktop devices.
-11. **Webhook**: Webhook is a generic webhook notification service.
+6. **Microsoft Teams**: Microsoft Teams is a collaboration platform that supports incoming webhooks for channel notifications.
+7. **Email**: Email is a popular method for sending messages to a group of recipients.
+8. **Resend**: Resend is a modern email API for developers to send transactional emails.
+9. **Gotify**: Gotify is a self-hosted push notification service.
+10. **Ntfy**: Ntfy is a simple HTTP-based pub-sub notification service.
+11. **Pushover**: Pushover is a service for sending real-time notifications to Android, iOS, and desktop devices.
+12. **Webhook**: Webhook is a generic webhook notification service.
 


### PR DESCRIPTION
- Added `mattermost.mdx` with setup instructions for Mattermost notifications.
- Updated `meta.json` to include Mattermost in the notifications navigation.
- Updated `overview.mdx` to list Mattermost as a supported provider.

Files carried over as-is from #138 by @hosseinmoghaddam, rebased onto current `main`.

Docs for Dokploy/dokploy#2728