### PR TITLE
docs: follow-up fixes to Dokku comparison entries

### DIFF
--- a/apps/docs/content/docs/core/comparison.mdx
+++ b/apps/docs/content/docs/core/comparison.mdx
@@ -18,7 +18,7 @@ Comparison of the following deployment tools:
 | **Gitea Integration**                   | ✅      | ❌                    | ✅                    | ❌      |
 | **Advanced User Permission Management** | ✅      | ❌                    | ❌                    | ❌      |
 | **Terminal Access Built In**            | ✅      | ❌                    | ❌                    | ✅      |
-| **Database Support**                    | ✅      | ✅                    | ❌                    | ✅      |
+| **Database Support**                    | ✅      | ✅                    | Available via Plugins | ✅      |
 | **Monitoring**                          | ✅      | ✅                    | ❌                    | ✅      |
 | **Backups**                             | ✅      | Available via Plugins | Available via Plugins | ✅      |
 | **Open Source**                         | ✅      | ✅                    | ✅                    | ✅      |
@@ -32,6 +32,6 @@ Comparison of the following deployment tools:
 | **Cloudflare Tunnels**                  | ✅      | ❌                    | Available via Plugins | ✅      |
 | **Custom Build Server**                 | ✅      | ❌                    | ❌                    | ✅      |
 | **Volume Backups**                      | ✅      | ❌                    | ❌                    | ❌      |
-| **Preview Deployments**                 | ✅      | ❌                    | ✅                    | ✅      | 
+| **Preview Deployments**                 | ✅      | ❌                    | Via GitHub Action     | ✅      | 
 | **Teams**                               | ✅      | ❌                    | ❌                    | ✅      |
 | **Cloud/Paid Version**                  | ✅      | ✅                    | ✅                    | ✅      |


### PR DESCRIPTION
Follow-up to #108, which was merged with two rows off:

- **Database Support** (Dokku): the merge conflict resolution dropped this change from the original PR — restored to "Available via Plugins" (postgres, mysql, redis, etc. are official plugins).
- **Preview Deployments** (Dokku): changed ✅ to "Via GitHub Action" — review apps in Dokku are set up through the [github-action Review Apps example](https://github.com/dokku/github-action?tab=readme-ov-file#examples) rather than built into the platform, so this follows the same convention as "Available via Plugins".

Thanks @josegonzalez for the corrections in #108.