### PR TITLE
fix: attach dokploy-network at Traefik creation in install.sh

### DIFF
--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -331,6 +331,7 @@ install_dokploy() {
     docker run -d \
         --name dokploy-traefik \
         --restart always \
+        --network dokploy-network \
         -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
         -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
         -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -338,8 +339,6 @@ install_dokploy() {
         -p 443:443/tcp \
         -p 443:443/udp \
         traefik:v3.6.7
-    
-    docker network connect dokploy-network dokploy-traefik
 
 
     # Optional: Use docker service create instead of docker run


### PR DESCRIPTION
Fresh installs created `dokploy-traefik` without `--network` and attached `dokploy-network` afterwards with `docker network connect`. Dynamic attachments like that are not restored after an ungraceful reboot (VM resize, power loss) — the container fails with `failed to set up container networking` and `--restart always` does not retry, which is the root cause behind dokploy/dokploy#4057 (reproduced on Docker 28.x and 29.x; details in https://github.com/Dokploy/dokploy/issues/4057#issuecomment-5230237907).

Networks defined in the container's create config survive the same crash reliably (verified repeatedly, including a full VM reboot), so the script now passes `--network dokploy-network` to `docker run` and drops the separate `docker network connect`. Safe at install time: the network is already materialized on the node because the postgres and dokploy services are attached to it before Traefik is created.

**History note:** this reverts f94ed01 (May 2025), which introduced the two-step connect for dokploy/dokploy#1802 / dokploy/dokploy#1809. Those reports were a different symptom — Traefik *running* but not routing after reboot (stale ARP/VIP state, upstream moby/moby#52661) — and the two-step didn't fix reboot recovery: dokploy/dokploy#3236 and dokploy/dokploy#4057 (Traefik fully dead after reboot) both happened after that change, caused by the dynamic attachment it introduced.