### PR TITLE
docs(secrets): add Phase.dev vault provider

### DIFF
--- a/apps/docs/content/docs/core/enterprise/audit-logs.mdx
+++ b/apps/docs/content/docs/core/enterprise/audit-logs.mdx
@@ -35,7 +35,7 @@ Audit Logs track every meaningful action in your organization:
 - **Infrastructure** — Changes to servers, registries, certificates, SSH keys, and S3 destinations.
 - **Backups & Schedules** — Creating, updating, or deleting backups, volume backups, and scheduled jobs.
 - **Notifications** — Changes to notification providers.
-- **Secrets Providers** — Creating, updating, or deleting connections to external secret managers (HashiCorp Vault / OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager). See [Secrets Providers](/docs/core/secrets-providers).
+- **Secrets Providers** — Creating, updating, or deleting connections to external secret managers (HashiCorp Vault / OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager, Phase). See [Secrets Providers](/docs/core/secrets-providers).
 - **DNS Providers** — Creating, updating, or deleting DNS provider connections (Cloudflare, AWS Route53). See [DNS Providers](/docs/core/dns-providers).
 
 ## Filtering

--- a/apps/docs/content/docs/core/enterprise/custom-roles.mdx
+++ b/apps/docs/content/docs/core/enterprise/custom-roles.mdx
@@ -228,7 +228,7 @@ View the audit log of actions performed in the organization.
 
 ### Secrets Providers
 
-Manage connections to external secret managers (HashiCorp Vault / OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager) used to reference secrets in environment variables. See [Secrets Providers](/docs/core/secrets-providers).
+Manage connections to external secret managers (HashiCorp Vault / OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager, Phase) used to reference secrets in environment variables. See [Secrets Providers](/docs/core/secrets-providers).
 
 - **Read** — View provider names and secret names (powers the `${{vault.*}}` autocomplete).
 - **Create** — Add new secrets providers.

--- a/apps/docs/content/docs/core/secrets-providers/index.mdx
+++ b/apps/docs/content/docs/core/secrets-providers/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Secrets Providers
-description: "Reference secrets from external secret managers (HashiCorp Vault, OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager) directly in your environment variables."
+description: "Reference secrets from external secret managers (HashiCorp Vault, OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager, Phase) directly in your environment variables."
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -28,6 +28,7 @@ Supported providers:
 - [Doppler](/docs/core/secrets-providers/doppler)
 - [Azure Key Vault](/docs/core/secrets-providers/azure)
 - [Scaleway Secret Manager](/docs/core/secrets-providers/scaleway)
+- [Phase](/docs/core/secrets-providers/phase)
 
 ## Reference Syntax
 
@@ -46,6 +47,7 @@ ${{vault.<provider-name>.<ref>}}
 | Doppler | `<SECRET_NAME>` | `DB_PASSWORD` |
 | Azure Key Vault | `<secret-name>` | `db-password` |
 | Scaleway Secret Manager | `[folder/]<secret-name>[:field]` | `prod/database:password` |
+| Phase | `<SECRET_NAME>` | `DB_PASSWORD` |
 
 References work in every place that flows into a deployment:
 

--- a/apps/docs/content/docs/core/secrets-providers/meta.json
+++ b/apps/docs/content/docs/core/secrets-providers/meta.json
@@ -6,6 +6,7 @@
 		"aws",
 		"doppler",
 		"azure",
-		"scaleway"
+		"scaleway",
+		"phase"
 	]
 }

--- a/apps/docs/content/docs/core/secrets-providers/phase.mdx
+++ b/apps/docs/content/docs/core/secrets-providers/phase.mdx
@@ -1,0 +1,46 @@
+---
+title: Phase
+description: "Use Phase.dev secrets in your Dokploy environment variables."
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+## Create a Service Account Token
+
+Dokploy talks to Phase over the **REST API** using a **Service Account** token. CLI/SDK `pss_*` tokens are not accepted for this integration.
+
+1. In Phase, open your organization and create (or open) a **Service Account**.
+2. Grant the account access to the App and Environment you want Dokploy to read.
+3. Create a **REST API token** for that Service Account and copy it.
+
+<Callout type="warn">
+  The Phase App must have **Server-side Encryption (SSE)** enabled. Without SSE, the REST secrets API cannot return decrypted values and Dokploy's Test Connection / deploy-time fetch will fail.
+</Callout>
+
+## Configuration
+
+In **Settings → Secrets → Add Provider**, choose **Phase** and fill in:
+
+- **Name**: the identifier used in references, e.g. `phase-prod`.
+- **Service Account REST API token**: the token from above.
+- **App ID**: the Phase App ID.
+- **Environment**: the Phase environment name (e.g. `production`).
+- **Path** (optional): secret path prefix; defaults to `/`.
+- **API URL** (optional): defaults to `https://api.phase.dev`. Self-hosted Phase usually uses your own API base URL.
+
+Use **Test Connection** to validate the token, App ID, environment, and SSE before saving, then assign the projects/environments where the provider may be used.
+
+<Callout type="info">
+  A provider points at a single Phase App + Environment (+ path). For several environments, create one provider per environment and assign each to the matching Dokploy environments.
+</Callout>
+
+## Reference Format
+
+Phase secrets are flat key/value pairs within the configured path, so references use the secret name directly:
+
+```bash
+DATABASE_URL=${{vault.phase-prod.DATABASE_URL}}
+STRIPE_KEY=${{vault.phase-prod.STRIPE_KEY}}
+```
+
+The autocomplete lists the real secret names returned by the Phase REST secrets API for that App/Environment/path.

--- a/apps/docs/content/docs/core/variables.mdx
+++ b/apps/docs/content/docs/core/variables.mdx
@@ -107,7 +107,7 @@ DATABASE_URL=postgresql://${{DATABASE_USER}}:${{DATABASE_PASSWORD}}@service-data
 
 ## Secrets from External Vaults
 
-Besides shared variables, you can reference secrets stored in an external secret manager (HashiCorp Vault/OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault):
+Besides shared variables, you can reference secrets stored in an external secret manager (HashiCorp Vault/OpenBao, Infisical, AWS Secrets Manager, Doppler, Azure Key Vault, Scaleway Secret Manager, Phase):
 
 ```bash
 DB_PASSWORD=${{vault.prod-vault.myapp/prod:DB_PASSWORD}}


### PR DESCRIPTION
## Summary
- Add a Phase secrets-provider doc page (Service Account REST token, SSE requirement, App ID / env / path / API URL).
- Link Phase from the secrets-providers index, `meta.json`, variables overview, and enterprise audit/custom-roles mentions.
- Companion to Dokploy/dokploy#5123 / Fixes Dokploy/dokploy#5122 (docs follow-up).

## Test plan
- [ ] Preview docs site; Phase page renders under Secrets Providers
- [ ] Nav/`meta.json` lists Phase after Scaleway
- [ ] Cross-links from index + variables resolve

Made with [Cursor](https://cursor.com)