### PR TITLE
docs: document Files System tab for applications, databases, and compose

### DIFF
--- a/apps/docs/content/docs/core/applications/index.mdx
+++ b/apps/docs/content/docs/core/applications/index.mdx
@@ -25,6 +25,12 @@ Four graphs will be displayed for the use of memory, CPU, disk, and network. Not
 
 If you want to see any important logs from your application that is running, you can do so here and determine if your application is displaying any errors or not.
 
+## Files System
+
+Browse the file system of your application's running container directly from the dashboard. You can navigate directories, preview text files, download any file, and upload new files into the directory you currently have open.
+
+Files outside persistent volumes are usually ephemeral and can disappear after a restart or a new deployment. Uploading requires the `Write` permission on the `Container Filesystem` resource for custom roles; owners and admins have it by default.
+
 ## Deployments
 
 You can view the last 10 deployments of your application. When you deploy your application in real time, a new deployment record will be created and it will gradually show you how your application is being built.

--- a/apps/docs/content/docs/core/databases/index.mdx
+++ b/apps/docs/content/docs/core/databases/index.mdx
@@ -41,6 +41,12 @@ We offer automated backups for your databases, ensuring that you can recover you
 
 If you want to see any important logs from your application that is running, you can do so here and determine if your application is displaying any errors or not.
 
+## Files System
+
+Browse the file system of your database's running container directly from the dashboard. You can navigate directories, preview text files, download any file, and upload new files into the directory you currently have open.
+
+Files outside persistent volumes are usually ephemeral and can disappear after a restart or a new deployment. Uploading requires the `Write` permission on the `Container Filesystem` resource for custom roles; owners and admins have it by default.
+
 ## Advanced
 
 This section provides advanced configuration options for experienced users. It includes tools for custom commands within the container, managing Docker Swarm settings, and adjusting cluster settings such as replicas and registry selection. These tools are typically not required for standard application deployment and are intended for complex management and troubleshooting tasks.

--- a/apps/docs/content/docs/core/docker-compose/index.mdx
+++ b/apps/docs/content/docs/core/docker-compose/index.mdx
@@ -53,6 +53,12 @@ Monitor each service individually within Dokploy. If your application consists o
 
 Access detailed logs for each service through the Dokploy log viewer, which can help in troubleshooting and ensuring the stability of your services.
 
+### Files System
+
+Browse the file system of any running container in your compose from the dashboard — pick the container from the dropdown, then navigate directories, preview text files, download any file, and upload new files into the directory you currently have open.
+
+Files outside persistent volumes are usually ephemeral and can disappear after a restart or a new deployment. Uploading requires the `Write` permission on the `Container Filesystem` resource for custom roles; owners and admins have it by default.
+
 ### Deployments
 
 You can view the last 10 deployments of your application. When you deploy your application in real time, a new deployment record will be created and it will gradually show you how your application is being built.


### PR DESCRIPTION
## What is this PR about?

This PR documents the new **Files System** tab that was added to Dokploy's Applications, Databases, and Docker Compose pages in [Dokploy/dokploy#5194](https://github.com/Dokploy/dokploy/pull/5194). That feature lets users browse, download, and upload files inside a running container directly from the dashboard, and is now available for applications, all database types (Postgres, MySQL, MariaDB, MongoDB, Redis), and Docker Compose services.

This PR adds a `## Files System` (`### Files System` on the Docker Compose page, matching that page's heading level) section to the three relevant docs pages, in the same place and style as the existing `General`/`Environment`/`Logs` sections:

- `apps/docs/content/docs/core/applications/index.mdx`
- `apps/docs/content/docs/core/databases/index.mdx`
- `apps/docs/content/docs/core/docker-compose/index.mdx`

Each section explains what the tab does, notes that files outside persistent volumes are ephemeral, and mentions that uploading requires the `Write` permission on the `Container Filesystem` resource (owners/admins have it by default; custom roles need it granted explicitly).

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `main` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Related to Dokploy/dokploy#5194

## Screenshots (if applicable)

<!-- Add a screenshot of the rendered "Files System" section on the Applications, Databases, or Docker Compose docs page. -->
